### PR TITLE
bin should never have "\r"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "lib": ["es2017"],
         "outDir": "bin",
         "sourceMap": true,
+        "newLine": "LF",
 
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,


### PR DESCRIPTION
We published on Windows, and now it can't be run on Unix because TypeScript added CRLF to the line endings.
Ref: npm/npm#12371