### PR TITLE
Disable no-object-literal-type-assertion

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
 
 		"no-console": false,
 		"no-namespace": false,
+		"no-object-literal-type-assertion": false,
 		"object-literal-sort-keys": false,
 		"switch-default": false
 	}


### PR DESCRIPTION
This rule is causing some problems on DefinitelyTyped and we'll have to fix it later.