### PR TITLE
Move "tslint" from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fs-promise": "^2.0.0",
     "parsimmon": "^1.2.0",
     "strip-json-comments": "^2.0.1",
+    "tslint": "^5.1.0",
     "tsutils": "^1.1.0"
   },
   "devDependencies": {
@@ -34,8 +35,7 @@
     "@types/mz": "0.0.30",
     "@types/node": "^7.0.5",
     "@types/parsimmon": "^1.0.3",
-    "@types/strip-json-comments": "0.0.28",
-    "tslint": "^5.1.0",
+    "@types/strip-json-comments": "^0.0.28",
     "typescript": "^2.3.0"
   },
   "engines": {


### PR DESCRIPTION
This isn't normally imported directly because we use `installs` for that instead, but since this determines the version of tslint installed, and it doesn't just happen at development time, it makes more sense to have this here.