### PR TITLE
Use "tslint:recommended" instead of "tslint:latest"

### DIFF
--- a/dtslint.json
+++ b/dtslint.json
@@ -1,5 +1,5 @@
 {
-    "extends": "tslint:latest",
+    "extends": "tslint:recommended",
     "rulesDirectory": "./bin/rules",
     "rules": {
         // Wait on 5.2 release (https://github.com/palantir/tslint/pull/2391)


### PR DESCRIPTION
This should prevent lint warnings from popping up unannounced each time a new tslint minor version is released.