### PR TITLE
Set `resolvedModules` on every source file so tslint thinks it is type checked

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -22,6 +22,14 @@ export async function lintWithVersion(
 	const linter = new Linter(lintOptions, program);
 	const config = await getLintConfig(lintConfigPath, tsconfigPath, version);
 
+	// tslint 5.3 demands that the program has been typechecked.
+	// Kludge to make tslint think the program has been type checked.
+	for (const sf of program.getSourceFiles()) {
+		if (!(sf as any).resolvedModules) {
+			(sf as any).resolvedModules = [];
+		}
+	}
+
 	for (const filename of program.getRootFileNames()) {
 		const contents = await readFile(filename, "utf-8");
 		linter.lint(filename, contents, config);

--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -83,7 +83,7 @@ function walk(ctx: Lint.WalkContext<void>, program: TsType.Program, ts: typeof T
 	const seenDiagnosticsOnLine = new Set<number>();
 
 	for (const diagnostic of diagnostics) {
-		const line = lineOfPosition(diagnostic.start, sourceFile);
+		const line = lineOfPosition(diagnostic.start!, sourceFile);
 		seenDiagnosticsOnLine.add(line);
 		if (!errorLines.has(line)) {
 			addDiagnosticFailure(diagnostic);
@@ -106,7 +106,7 @@ function walk(ctx: Lint.WalkContext<void>, program: TsType.Program, ts: typeof T
 
 	function addDiagnosticFailure(diagnostic: TsType.Diagnostic): void {
 		if (diagnostic.file === sourceFile) {
-			ctx.addFailureAt(diagnostic.start, diagnostic.length,
+			ctx.addFailureAt(diagnostic.start!, diagnostic.length!,
 				"TypeScript compile error: " + ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
 		} else {
 			ctx.addFailureAt(0, 0, `TypeScript compile error: ${diagnostic.file}: ${diagnostic.messageText}`);


### PR DESCRIPTION
This will be fixed by palantir/tslint#2773, so this is just a workaround until then.