### PR TITLE
Change `expect` options to use the path to TypeScript instead of the version

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,8 +1,6 @@
-import assert = require("assert");
 import { exec } from "child_process";
 import * as fsp from "fs-promise";
 import * as path from "path";
-import * as TsType from "typescript";
 
 import { TypeScriptVersion } from "./rules/definitelytyped-header-parser";
 
@@ -26,19 +24,16 @@ export async function install(version: TypeScriptVersion | "next"): Promise<void
 	}
 }
 
-export function getTypeScript(version: TypeScriptVersion | "next"): typeof TsType {
-	const tsPath = path.join(installDir(version), "node_modules", "typescript");
-	const ts = require(tsPath) as typeof TsType;
-	assert(version === "next" || ts.version.startsWith(version));
-	return ts;
-}
-
 export function cleanInstalls(): Promise<void> {
 	return fsp.remove(installsDir);
 }
 
+export function typeScriptPath(version: TypeScriptVersion | "next"): string {
+	return path.join(installDir(version), "node_modules", "typescript");
+}
+
 export function tscPath(version: TypeScriptVersion | "next"): string {
-	return path.join(installDir(version), "node_modules", "typescript", "lib", "tsc.js");
+	return path.join(typeScriptPath(version), "lib", "tsc.js");
 }
 
 function installDir(version: TypeScriptVersion | "next"): string {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -7,6 +7,7 @@ type IConfigurationFile = Configuration.IConfigurationFile;
 import { TypeScriptVersion } from "./rules/definitelytyped-header-parser";
 import { Options as ExpectOptions } from "./rules/expectRule";
 
+import { typeScriptPath } from "./installer";
 import { readJson } from "./util";
 
 export async function lintWithVersion(
@@ -72,7 +73,7 @@ async function getLintConfig(
 	if (!config) {
 		throw new Error(`Could not load config at ${configPath}`);
 	}
-	const expectOptions: ExpectOptions = { tsconfigPath, typeScriptVersion };
+	const expectOptions: ExpectOptions = { tsconfigPath, typeScriptPath: typeScriptPath(typeScriptVersion) };
 	config.rules.get("expect")!.ruleArguments = [expectOptions];
 	return config;
 }

--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -3,9 +3,6 @@ import { dirname, resolve as resolvePath } from "path";
 import * as Lint from "tslint";
 import * as TsType from "typescript";
 
-import { getTypeScript } from "../installer";
-import { TypeScriptVersion } from "./definitelytyped-header-parser";
-
 // Based on https://github.com/danvk/typings-checker
 
 export class Rule extends Lint.Rules.TypedRule {
@@ -33,7 +30,7 @@ export class Rule extends Lint.Rules.TypedRule {
 		const options = this.ruleArguments[0] as Options | undefined;
 		let ts = TsType;
 		if (options) {
-			ts = getTypeScript(options.typeScriptVersion);
+			ts = require(options.typeScriptPath);
 			program = createProgram(options.tsconfigPath, ts, program);
 		}
 		return this.applyWithFunction(sourceFile, ctx => walk(ctx, program, ts));
@@ -42,7 +39,7 @@ export class Rule extends Lint.Rules.TypedRule {
 
 export interface Options {
 	tsconfigPath: string;
-	typeScriptVersion: TypeScriptVersion | "next";
+	typeScriptPath: string;
 }
 
 function createProgram(configFile: string, ts: typeof TsType, _oldProgram: TsType.Program): TsType.Program {


### PR DESCRIPTION
A problem was happening when two dtslint installs existed. One was in types-publisher, the other was in DefinitelyTyped. We would install typescript versions in the types-publisher one, but the tslint rulesDirectory would resolve to the dtslint install in DefinitelyTyped, which would then `require()` from its own `typescriptInstalls` and fail.
