### PR TITLE
In `expect`, memoize `createProgram`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fs-promise": "^2.0.0",
     "parsimmon": "^1.2.0",
     "strip-json-comments": "^2.0.1",
-    "tslint": "^5.1.0",
+    "tslint": "^5.4.2",
     "typescript": "next"
   },
   "devDependencies": {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -23,14 +23,6 @@ export async function lintWithVersion(
 	const linter = new Linter(lintOptions, program);
 	const config = await getLintConfig(lintConfigPath, tsconfigPath, version);
 
-	// tslint 5.3 demands that the program has been typechecked.
-	// Kludge to make tslint think the program has been type checked.
-	for (const sf of program.getSourceFiles()) {
-		if (!(sf as any).resolvedModules) {
-			(sf as any).resolvedModules = [];
-		}
-	}
-
 	for (const filename of program.getRootFileNames()) {
 		const contents = await readFile(filename, "utf-8");
 		linter.lint(filename, contents, config);


### PR DESCRIPTION
This rule was taking O(n^2) time based on the number of input files, because it created a new Program every time it was run. Added memoization so that it only creates 1 additional program.