### PR TITLE
Allow `dtslint types @bla/foo`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,11 @@ async function main(): Promise<void> {
 					process.exit(1);
 				}
 
+				if (arg.indexOf('@') === 0 && arg.indexOf('/') !== -1) {
+					// we have a scoped module, e.g. @bla/foo
+					// which should be converted to   bla__foo
+					arg = arg.substr(1).replace('/', '__');
+				}
 				dirPath = dirPath === undefined ? arg : joinPaths(dirPath, arg);
 		}
 	}


### PR DESCRIPTION
Currently when running `npm run lint @bla/foo` in https://github.com/DefinitelyTyped/DefinitelyTyped it errors with:

```
➜  DefinitelyTyped git:(add-@storybook__react) ✗ npm run lint @storybook/react

> definitely-typed@0.0.1 lint /Users/joscha/Development/DefinitelyTyped
> dtslint types "@storybook/react"

ENOENT: no such file or directory, open '/Users/joscha/Development/DefinitelyTyped/types/@storybook/react/index.d.ts'

npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "lint" "@storybook/react"
npm ERR! node v7.5.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! definitely-typed@0.0.1 lint: `dtslint types "@storybook/react"`
npm ERR! Exit status 1
```

for scoped packages.

references https://github.com/Microsoft/dts-gen/pull/63, https://github.com/DefinitelyTyped/dt-review-tool/pull/11

Workaround is currently to run `npm run lint storybook__react`