### PR TITLE
Check array bounds in noPaddingRule

### DIFF
--- a/src/rules/noPaddingRule.ts
+++ b/src/rules/noPaddingRule.ts
@@ -26,7 +26,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
 				case ts.SyntaxKind.OpenParenToken:
 				case ts.SyntaxKind.OpenBracketToken:
 				case ts.SyntaxKind.OpenBraceToken:
-					if (blankLineInBetween(child.getEnd(), children[i + 1].getStart())) {
+					if (i < children.length - 1 && blankLineInBetween(child.getEnd(), children[i + 1].getStart())) {
 						fail("after");
 					}
 					break;
@@ -34,7 +34,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
 				case ts.SyntaxKind.CloseParenToken:
 				case ts.SyntaxKind.CloseBracketToken:
 				case ts.SyntaxKind.CloseBraceToken:
-					if (blankLineInBetween(child.getStart() - 1, children[i - 1].getEnd() - 1)) {
+					if (i > 0 && blankLineInBetween(child.getStart() - 1, children[i - 1].getEnd() - 1)) {
 						fail("before");
 					}
 					break;


### PR DESCRIPTION
It's rare, but if there was a parse problem, an `(` could be the last token, or a `)` could be the first token. We should avoid crashing in that case.