### PR TITLE
Add 'no-declare-current-package' rule

### DIFF
--- a/docs/no-declare-current-package.md
+++ b/docs/no-declare-current-package.md
@@ -1,0 +1,35 @@
+# no-declare-current-package
+
+Avoid using `declare module`, and prefer to declare module contents in a file.
+
+**Bad**:
+
+```ts
+// foo/index.d.ts
+declare module "foo" {
+    export const x = 0;
+}
+```
+
+**Good**:
+
+```ts
+// foo/index.d.ts
+export const x = 0;
+```
+
+**Bad**:
+
+```ts
+// foo/index.d.ts
+declare module "foo/bar" {
+    export const x = 0;
+}
+```
+
+**Good**:
+
+```ts
+// foo/bar.d.ts
+export const x = 0;
+```

--- a/dt.json
+++ b/dt.json
@@ -3,6 +3,7 @@
 	"rules": {
 		"dt-header": true,
 		"no-bad-reference": true,
+		"no-declare-current-package": true,
 		"no-self-import": true
 	}
 }

--- a/src/rules/noDeclareCurrentPackageRule.ts
+++ b/src/rules/noDeclareCurrentPackageRule.ts
@@ -1,0 +1,39 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+import { failure, getCommonDirectoryName } from "../util";
+
+export class Rule extends Lint.Rules.TypedRule {
+	static metadata: Lint.IRuleMetadata = {
+		ruleName: "no-declare-current-package",
+		description: "Don't use an ambient module declaration of the current package; use an external module.",
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "functionality",
+		typescriptOnly: true,
+	};
+
+	applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+		if (!sourceFile.isDeclarationFile) {
+			return [];
+		}
+
+		const packageName = getCommonDirectoryName(program.getRootFileNames());
+		return this.applyWithFunction(sourceFile, ctx => walk(ctx, packageName));
+	}
+}
+
+function walk(ctx: Lint.WalkContext<void>, packageName: string): void {
+	for (const statement of ctx.sourceFile.statements) {
+		if (ts.isModuleDeclaration(statement) && ts.isStringLiteral(statement.name)) {
+			const { text } = statement.name;
+			if (text === packageName || text.startsWith(`${packageName}/`)) {
+				const preferred = text === packageName ? '"index.d.ts"' : `"${text}.d.ts" or "${text}/index.d.ts`;
+				ctx.addFailureAtNode(statement.name, failure(
+					Rule.metadata.ruleName,
+					`Instead of declaring a module with \`declare module "${text}"\`, ` +
+					`write its contents in directly in ${preferred}.`));
+			}
+		}
+	}
+}

--- a/src/rules/noSelfImportRule.ts
+++ b/src/rules/noSelfImportRule.ts
@@ -1,9 +1,7 @@
-import { basename, dirname } from "path";
-
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
-import { failure } from "../util";
+import { failure, getCommonDirectoryName } from "../util";
 
 export class Rule extends Lint.Rules.TypedRule {
 	static metadata: Lint.IRuleMetadata = {
@@ -20,7 +18,7 @@ export class Rule extends Lint.Rules.TypedRule {
 			return [];
 		}
 
-		const name = getCommonDirectoryName(program.getSourceFiles());
+		const name = getCommonDirectoryName(program.getRootFileNames());
 		return this.applyWithFunction(sourceFile, ctx => walk(ctx, name));
 	}
 }
@@ -28,19 +26,6 @@ export class Rule extends Lint.Rules.TypedRule {
 const FAILURE_STRING = failure(
 	Rule.metadata.ruleName,
 	"Declaration file should not use a global import of itself. Use a relative import.");
-
-function getCommonDirectoryName(files: ReadonlyArray<ts.SourceFile>): string {
-	let minLen = 999;
-	let minDir = "";
-	for (const file of files) {
-		const dir = dirname(file.fileName);
-		if (dir.length < minLen) {
-			minDir = dir;
-			minLen = dir.length;
-		}
-	}
-	return basename(minDir);
-}
 
 function walk(ctx: Lint.WalkContext<void>, packageName: string): void {
 	for (const i of ctx.sourceFile.imports) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { readFile } from "fs-promise";
+import { basename, dirname } from "path";
 import stripJsonComments = require("strip-json-comments");
 
 export async function readJson(path: string) {
@@ -8,4 +9,17 @@ export async function readJson(path: string) {
 
 export function failure(ruleName: string, s: string): string {
 	return `${s} See: https://github.com/Microsoft/dtslint/blob/master/docs/${ruleName}.md`;
+}
+
+export function getCommonDirectoryName(files: ReadonlyArray<string>): string {
+	let minLen = 999;
+	let minDir = "";
+	for (const file of files) {
+		const dir = dirname(file);
+		if (dir.length < minLen) {
+			minDir = dir;
+			minLen = dir.length;
+		}
+	}
+	return basename(minDir);
 }


### PR DESCRIPTION
Should prevent writing `declare module "foo/bar"` where a file `foo/bar.d.ts` would have worked.