### PR TITLE
Require strictFunctionTypes in tsconfig.json

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -62,6 +62,7 @@ export async function checkTsconfig(dirPath: string, dt: boolean): Promise<void>
 				case "noImplicitAny":
 				case "noImplicitThis":
 				case "strictNullChecks":
+				case "strictFunctionTypes":
 					break;
 				case "target":
 				case "paths":
@@ -83,7 +84,7 @@ export async function checkTsconfig(dirPath: string, dt: boolean): Promise<void>
 		throw new Error('Must specify "lib", usually to `"lib": ["es6"]` or `"lib": ["es6", "dom"]`.');
 	}
 
-	for (const key of ["noImplicitAny", "noImplicitThis", "strictNullChecks"]) {
+	for (const key of ["noImplicitAny", "noImplicitThis", "strictNullChecks", "strictFunctionTypes"]) {
 		if (!(key in options)) {
 			throw new Error(`Expected \`"${key}": true\` or \`"${key}": false\`.`);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ async function test(dirPath: string, noLint: boolean, minVersion: TypeScriptVers
 		for (const tsVersion of ["next" as "next", minVersion]) {
 			// Special for old DefinitelyTyped packages that aren't linted yet.
 			const err = await execScript("node " + tscPath(tsVersion), dirPath);
-			if (err !== undefined) {
+			if (err !== undefined && err.trim() !== "error TS5023: Unknown compiler option 'strictFunctionTypes'.") {
 				return `Error in TypeScript@${tsVersion}: ${err}`;
 			}
 		}


### PR DESCRIPTION
"Unknown compiler option" error will be ignored to retain compatibility with typescript < 2.6.