### PR TITLE
Add `no-outside-dependencies` lint rule

### DIFF
--- a/docs/no-outside-dependencies.md
+++ b/docs/no-outside-dependencies.md
@@ -1,0 +1,23 @@
+# no-outside-dependencies
+
+Don't import from `DefinitelyTyped/node_modules`.
+
+**Bad**:
+
+```ts
+import * as x from "x";
+// where 'x' is defined only in `DefinitelyTyped/node_modules`
+```
+
+**Good**:
+
+Add a `package.json`:
+
+```ts
+{
+    "private": true,
+    "dependencies": {
+        "x": "^1.2.3"
+    }
+}
+```

--- a/dt.json
+++ b/dt.json
@@ -5,6 +5,7 @@
 		"no-bad-reference": true,
 		"no-declare-current-package": true,
 		"no-self-import": true,
+		"no-outside-dependencies": true,
 
 		"no-redundant-jsdoc": false,
 		"no-redundant-jsdoc-2": true

--- a/src/rules/noOutsideDependenciesRule.ts
+++ b/src/rules/noOutsideDependenciesRule.ts
@@ -1,0 +1,36 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+import { failure } from "../util";
+
+export class Rule extends Lint.Rules.TypedRule {
+	static metadata: Lint.IRuleMetadata = {
+		ruleName: "no-outside-dependencies",
+		description: "Don't import things in `DefinitelyTyped/node_modules`.",
+		optionsDescription: "Not configurable.",
+		options: null,
+		type: "functionality",
+		typescriptOnly: true,
+	};
+
+	applyWithProgram(_sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+		if (seenPrograms.has(program)) {
+			return [];
+		}
+		seenPrograms.add(program);
+
+		const failures: Lint.RuleFailure[] = [];
+		for (const sourceFile of program.getSourceFiles()) {
+			const { fileName } = sourceFile;
+			if (fileName.includes("/DefinitelyTyped/node_modules/")) {
+				const msg = failure(
+					Rule.metadata.ruleName,
+					`File ${fileName} comes from a \`node_modules\` but is not declared in this type's \`package.json\`. `);
+				failures.push(new Lint.RuleFailure(sourceFile, 0, 1, msg, Rule.metadata.ruleName));
+			}
+		}
+		return failures;
+	}
+}
+
+const seenPrograms = new WeakSet<ts.Program>();


### PR DESCRIPTION
Prevents packages from depending on things in `DefinitelyTyped/node_modules`.