### PR TITLE
tslint cli argument name was changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Note: If changing a lint rule, you will have to `dtslint --clean` because rules 
 ## Test
 
 Use `npm run test` to run all tests.
-To run a single test: `node node_modules/tslint/bin/tslint --rulesDirectory bin/rules --test test/expect`.
+To run a single test: `node node_modules/tslint/bin/tslint --rules-dir bin/rules --test test/expect`.
 
 
 ## Publish


### PR DESCRIPTION
`rulesDirectory` causes `error: unknown option '--rulesDirectory'`. [cli documentation](https://palantir.github.io/tslint/usage/cli/) only mentions `rules-dir`.