### PR TITLE
Removing ` from good example in dt-header

### DIFF
--- a/docs/dt-header.md
+++ b/docs/dt-header.md
@@ -32,7 +32,7 @@ Checks the format of DefinitelyTyped header comments.
 **Good**:
 
 ```ts
-// Definitions by: My Name <https://github.com/myname>`
+// Definitions by: My Name <https://github.com/myname>
 ```
 
 * Prefer a GitHub username, not a personal web site.


### PR DESCRIPTION
Assuming that the ` at the end of the "good example" of the "Definitions by" shouldn't be there.