### PR TITLE
Switch module fs-promise to fs-extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "dtslint",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/fs-extra": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-2.1.0.tgz",
-      "integrity": "sha1-izUCOcBFXZK408Ym7awZOGD/OV8=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
+      "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.56"
+        "@types/node": "*"
       }
     },
     "@types/mz": {
@@ -19,7 +19,7 @@
       "integrity": "sha1-WNqp81gR1gcDe6sfnMfUoj5qr64=",
       "dev": true,
       "requires": {
-        "@types/node": "7.0.56"
+        "@types/node": "*"
       }
     },
     "@types/node": {
@@ -49,17 +49,12 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "babel-code-frame": {
@@ -67,9 +62,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -77,11 +72,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         }
       }
@@ -96,7 +91,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -110,9 +105,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
       "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.3.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -120,7 +115,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -128,7 +123,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -138,7 +133,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -157,10 +152,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "definitelytyped-header-parser": {
-      "version": "github:Microsoft/definitelytyped-header-parser#f074e863231ef0d79a31c0a9edaf1b82c98469ef",
+      "version": "github:Microsoft/definitelytyped-header-parser#f152526f82f51d2baf91a99a397b449342b52db1",
+      "from": "github:Microsoft/definitelytyped-header-parser#production",
       "requires": {
-        "@types/parsimmon": "1.6.1",
-        "parsimmon": "1.7.0"
+        "@types/parsimmon": "^1.3.0",
+        "parsimmon": "^1.2.0"
       }
     },
     "diff": {
@@ -184,23 +180,13 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "fs-extra": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
-      }
-    },
-    "fs-promise": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
-      "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "fs-extra": "2.1.2",
-        "mz": "2.7.0",
-        "thenify-all": "1.6.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -213,12 +199,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -231,7 +217,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -244,8 +230,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -263,16 +249,16 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "minimatch": {
@@ -280,36 +266,21 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
-    },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
-      }
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parsimmon": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.7.0.tgz",
-      "integrity": "sha512-N78f2hfqGyApxDbrUc9N/Fn+3pHgQs7/sUulBmdFvQXxCYmFS6PrU5sISgsKdCnZthzXS4dQtMz+Y4rOootKdg=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.7.3.tgz",
+      "integrity": "sha512-ZkEqdG3ygzGAa44cDEDAgQoslSSIOVuTw7k1Yct+2AX+3JkezNWBuzz2ON/j7RhxXptTQC7rwGxPg//rDFTvqQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -326,7 +297,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "semver": {
@@ -344,7 +315,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-json-comments": {
@@ -357,22 +328,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "requires": {
-        "thenify": "3.3.0"
-      }
-    },
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
@@ -383,18 +338,18 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.3.2",
-        "commander": "2.15.0",
-        "diff": "3.5.0",
-        "glob": "7.1.2",
-        "js-yaml": "3.11.0",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "semver": "5.5.0",
-        "tslib": "1.9.0",
-        "tsutils": "2.22.2"
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.12.1"
       }
     },
     "tsutils": {
@@ -402,13 +357,18 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.22.2.tgz",
       "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "^1.8.1"
       }
     },
     "typescript": {
-      "version": "2.9.0-dev.20180422",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.0-dev.20180422.tgz",
-      "integrity": "sha512-ZoshrwzODq7xGMgxo5o1NimTC3+9W+eeSdgiDY6gd8KTtzm0roLk1LlVheUrqGWmpZO8rTdP3tCKsuBIPf7R4A=="
+      "version": "3.0.0-dev.20180522",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-dev.20180522.tgz",
+      "integrity": "sha512-/8nx63FE39r823Z07e9UnTQ2/L50iu4EWaonNxU7zY1BPHjl7ezWK1tAP7pAJpGbxdCAt+j0Xt88/MqdTM57rg=="
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   },
   "dependencies": {
     "definitelytyped-header-parser": "Microsoft/definitelytyped-header-parser#production",
-    "fs-promise": "^2.0.0",
+    "fs-extra": "^6.0.1",
     "strip-json-comments": "^2.0.1",
     "tslint": "^5.9.1",
     "typescript": "next"
   },
   "devDependencies": {
-    "@types/fs-extra": "^2.0.0",
+    "@types/fs-extra": "^5.0.2",
     "@types/mz": "0.0.30",
     "@types/node": "^7.0.5",
     "@types/parsimmon": "^1.0.3",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,4 +1,4 @@
-import { exists } from "fs-promise";
+import { pathExists } from "fs-extra";
 import * as path from "path";
 import { CompilerOptions } from "typescript";
 
@@ -6,7 +6,7 @@ import { readJson } from "./util";
 
 export async function checkPackageJson(dirPath: string): Promise<void> {
 	const pkgJsonPath = path.join(dirPath, "package.json");
-	if (!await exists(pkgJsonPath)) {
+	if (!await pathExists(pkgJsonPath)) {
 		return;
 	}
 	const pkgJson = await readJson(pkgJsonPath) as {};
@@ -29,7 +29,7 @@ export async function checkPackageJson(dirPath: string): Promise<void> {
 
 export async function checkTsconfig(dirPath: string, dt: boolean): Promise<void> {
 	const tsconfigPath = path.join(dirPath, "tsconfig.json");
-	if (!await exists(tsconfigPath)) {
+	if (!await pathExists(tsconfigPath)) {
 		throw new Error(`Need a 'tsconfig.json' file in ${dirPath}`);
 	}
 	const tsconfig = await readJson(tsconfigPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
-import { readFile } from "fs-promise";
+import { readFile } from "fs-extra";
 import { basename, dirname, join as joinPaths } from "path";
 
 import { checkPackageJson, checkTsconfig } from "./checks";

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,6 +1,6 @@
 import { exec } from "child_process";
 import { TypeScriptVersion } from "definitelytyped-header-parser";
-import * as fsp from "fs-promise";
+import * as fs from "fs-extra";
 import * as path from "path";
 
 const installsDir = path.join(__dirname, "..", "typescript-installs");
@@ -14,17 +14,17 @@ export async function installAll() {
 
 async function install(version: TypeScriptVersion | "next"): Promise<void> {
 	const dir = installDir(version);
-	if (!await fsp.existsSync(dir)) {
+	if (!await fs.pathExists(dir)) {
 		console.log(`Installing to ${dir}...`);
-		await fsp.mkdirp(dir);
-		await fsp.writeJson(path.join(dir, "package.json"), packageJson(version));
+		await fs.mkdirp(dir);
+		await fs.writeJson(path.join(dir, "package.json"), packageJson(version));
 		await execAndThrowErrors("npm install --ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links", dir);
 		console.log("Installed!");
 	}
 }
 
 export function cleanInstalls(): Promise<void> {
-	return fsp.remove(installsDir);
+	return fs.remove(installsDir);
 }
 
 export function typeScriptPath(version: TypeScriptVersion | "next"): string {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,5 +1,5 @@
 import { TypeScriptVersion } from "definitelytyped-header-parser";
-import { exists, readFile } from "fs-promise";
+import { pathExists, readFile } from "fs-extra";
 import { join as joinPaths } from "path";
 import { Configuration, ILinterOptions, Linter } from "tslint";
 type Configuration = typeof Configuration;
@@ -67,7 +67,7 @@ function testNoTslintDisables(text: string): Err | undefined {
 export async function checkTslintJson(dirPath: string, dt: boolean): Promise<void> {
 	const configPath = getConfigPath(dirPath);
 	const shouldExtend = `dtslint/${dt ? "dt" : "dtslint"}.json`;
-	if (!await exists(configPath)) {
+	if (!await pathExists(configPath)) {
 		if (dt) {
 			throw new Error(
 				`On DefinitelyTyped, must include \`tslint.json\` containing \`{ "extends": "${shouldExtend}" }\`.\n` +
@@ -92,7 +92,8 @@ async function getLintConfig(
 	minVersion: TypeScriptVersion,
 	onlyTestTsNext: boolean,
 ): Promise<IConfigurationFile> {
-	const configPath = await exists(expectedConfigPath) ? expectedConfigPath : joinPaths(__dirname, "..", "dtslint.json");
+	const configExists = await pathExists(expectedConfigPath);
+	const configPath = configExists ? expectedConfigPath : joinPaths(__dirname, "..", "dtslint.json");
 	// Second param to `findConfiguration` doesn't matter, since config path is provided.
 	const config = Configuration.findConfiguration(configPath, "").results;
 	if (!config) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs-promise";
+import { readFile } from "fs-extra";
 import { basename, dirname } from "path";
 import stripJsonComments = require("strip-json-comments");
 import * as ts from "typescript";


### PR DESCRIPTION
The owner of fs-promise deprecated it and recommends using fs-extra.

I ran build/lint/test against Node.js versions `6.10.2`, `8.11.2`, and `10.2.1`.