### PR TITLE
Update README.md's example tsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Refer to the [handbook](http://www.typescriptlang.org/docs/handbook/declaration-
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "noEmit": true,
 
         // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".


### PR DESCRIPTION
If you just C&P'd like I did, you get:

```sh
Error: Expected `"strictNullChecks": true` or `"strictNullChecks": false`.
    at Object.<anonymous> (/Users/orta/dev/projects/oss/js/tipsi-stripe/node_modules/dtslint/bin/checks.js:97:23)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/orta/dev/projects/oss/js/tipsi-stripe/node_modules/dtslint/bin/checks.js:4:58)
```

This sets a reasonable default.