### PR TITLE
Respect "extends" in tsconfig.json

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,8 +1,7 @@
 import { pathExists } from "fs-extra";
 import * as path from "path";
-import { CompilerOptions } from "typescript";
 
-import { readJson } from "./util";
+import { getCompilerOptions, readJson } from "./util";
 
 export async function checkPackageJson(dirPath: string): Promise<void> {
 	const pkgJsonPath = path.join(dirPath, "package.json");
@@ -28,13 +27,7 @@ export async function checkPackageJson(dirPath: string): Promise<void> {
 }
 
 export async function checkTsconfig(dirPath: string, dt: boolean): Promise<void> {
-	const tsconfigPath = path.join(dirPath, "tsconfig.json");
-	if (!await pathExists(tsconfigPath)) {
-		throw new Error(`Need a 'tsconfig.json' file in ${dirPath}`);
-	}
-	const tsconfig = await readJson(tsconfigPath);
-
-	const options: CompilerOptions = tsconfig.compilerOptions;
+	const options = await getCompilerOptions(dirPath);
 
 	if (dt) {
 		const isOlderVersion = /^v\d+$/.test(path.basename(dirPath));


### PR DESCRIPTION
Currently using dtslint in the root of a monorepo requires calling the cli for each package which requires that each package holds a tsconfig which is reasonable enough but ignores the `extends` property in those files. 

This pull requests use the typescript api to parse the tsconfig similar to how `tsc` would do it. The code is largely inspired by https://github.com/palantir/tslint/blob/788f64c9b101ef719290a62f7d67ca5162d821e4/src/linter.ts#L58-L83. Typescript currently does not include definitons for `parseConfigFileWithSystem` (but is exported) which is used by `tsc` https://github.com/Microsoft/TypeScript/blob/92205cf3e4ec06abfaa7e139bcc3dc2090a5294f/src/tsc/tsc.ts#L146

After writing this and fully realizing from where I took this code I went ahead and just used `tslint` while using the rules from this package (which works perfectly fine) and now I'm wondering why a cli exists for this package. Why is this not just `tslint-plugin-*` package?