### PR TITLE
Fix typescript version issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.67"
       }
     },
     "@types/mz": {
@@ -19,7 +19,7 @@
       "integrity": "sha1-WNqp81gR1gcDe6sfnMfUoj5qr64=",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "7.0.67"
       }
     },
     "@types/node": {
@@ -54,7 +54,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "babel-code-frame": {
@@ -62,9 +62,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -72,11 +72,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         }
       }
@@ -91,7 +91,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -105,9 +105,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -115,7 +115,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "supports-color": {
@@ -123,7 +123,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -153,10 +153,9 @@
     },
     "definitelytyped-header-parser": {
       "version": "github:Microsoft/definitelytyped-header-parser#a485d0e3f394da4d8628f36bf5b9700102f6b014",
-      "from": "github:Microsoft/definitelytyped-header-parser#production",
       "requires": {
-        "@types/parsimmon": "^1.3.0",
-        "parsimmon": "^1.2.0"
+        "@types/parsimmon": "1.10.0",
+        "parsimmon": "1.12.0"
       }
     },
     "diff": {
@@ -184,9 +183,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
       "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs.realpath": {
@@ -199,12 +198,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -217,7 +216,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -230,8 +229,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -249,8 +248,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsonfile": {
@@ -258,7 +257,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "minimatch": {
@@ -266,7 +265,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "once": {
@@ -274,13 +273,13 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "parsimmon": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.11.1.tgz",
-      "integrity": "sha512-HYAWQoaMIrenEt2qToREaCCH1D3d1FBdn/YHPfIBmnFI9cMNABIaj4jga1gr6mtif3Wtm58Ya2LRqUz6HdHS/g=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.12.0.tgz",
+      "integrity": "sha512-uC/BjuSfb4jfaWajKCp1mVncXXq+V1twbcYChbTxN3GM7fn+8XoHwUdvUz+PTaFtDSCRQxU8+Rnh+iMhAkVwdw=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -297,7 +296,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "semver": {
@@ -315,7 +314,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-json-comments": {
@@ -338,18 +337,18 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
       "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.16.0",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.12.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.8.1",
+        "semver": "5.5.0",
+        "tslib": "1.9.3",
+        "tsutils": "2.27.2"
       }
     },
     "tsutils": {
@@ -357,13 +356,14 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.2.tgz",
       "integrity": "sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==",
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.3"
       }
     },
     "typescript": {
-      "version": "3.0.0-dev.20180707",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.0-dev.20180707.tgz",
-      "integrity": "sha512-AP1tZuUy4CW716f/m2F8LK6U25x/FV1+96hTnruCHiuFFIUx8XbFH8h/0azebb7xNvxGollTraW8VQxD29VFCA=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -27,15 +27,18 @@
     "definitelytyped-header-parser": "Microsoft/definitelytyped-header-parser#production",
     "fs-extra": "^6.0.1",
     "strip-json-comments": "^2.0.1",
-    "tslint": "^5.9.1",
-    "typescript": "next"
+    "tslint": "^5.9.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.2",
     "@types/mz": "0.0.30",
     "@types/node": "^7.0.5",
     "@types/parsimmon": "^1.0.3",
-    "@types/strip-json-comments": "^0.0.28"
+    "@types/strip-json-comments": "^0.0.28",
+    "typescript": "^2.9.2"
+  },
+  "peerDependencies": {
+    "typescript": ">=2.5.0 || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
   },
   "engines": {
     "node": ">=6.10.0"


### PR DESCRIPTION
Listing `typescript` as a direct dependency can cause `tslint` to pass an AST from an older version to a `typescript` version that introduced breaking changes. Since `dtslint` acts as a plugin to `tslint` it should use the same version.

I incrementally increased the minor version from typescript until all tests where passing (which happened at 2.5.0). Using a newer version for development is still fine since it's mostly related to disallowed fallthroughs or undefined enum values.

This is in line with other tslint plugins such as `tslint-plugin-prettier` or `tslint-no-circular-imports` which also list `typescript` as a peer. 

This will cause additional errors when using in DefinitelyTyped for packages with older typescript version but those are warranted because tests are failing for those versions.

I used `npm@5.6.0` to reinstall the packages which added a significant amount of noise to the lockfile diff. If I'd knew the originally used npm version I could use that version and repeat the steps to remove noise.

__Related Issues__:
* #119 
* #115 