### PR TITLE
Revert #130: load tsconfig with just readjson, not ts.parseJsonConfigFileContent

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -57,22 +57,5 @@ export async function getCompilerOptions(dirPath: string): Promise<ts.CompilerOp
 	if (!await pathExists(tsconfigPath)) {
 		throw new Error(`Need a 'tsconfig.json' file in ${dirPath}`);
 	}
-
-	const formatDiagnosticHost: ts.FormatDiagnosticsHost = {
-		getCanonicalFileName: (fileName: string) => fileName,
-		getCurrentDirectory: ts.sys.getCurrentDirectory,
-		getNewLine: () => "\n",
-	};
-
-	const { config, error } = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
-	if (error != null) {
-		throw new Error(ts.formatDiagnostic(error, formatDiagnosticHost));
-	}
-
-	const { errors, options } = ts.parseJsonConfigFileContent(config, ts.sys, dirPath);
-	if (errors.length > 0) {
-		throw new Error(ts.formatDiagnostics(errors, formatDiagnosticHost));
-	}
-
-	return options;
+	return (await readJson(tsconfigPath)).compilerOptions;
 }


### PR DESCRIPTION
#130 broke tests because `ts.parseJsonConfigFileContent` processes the options and changes them.
It looks like the user who submitted that PR @eps1lon was attempting to use some dtslint rules in a regular TypeScript repo, so a better solution would be to move those rules upstream or publish them independently.