### PR TITLE
Enable no-angle-bracket-type-assertion

### DIFF
--- a/dtslint.json
+++ b/dtslint.json
@@ -87,7 +87,6 @@
 		"member-ordering": false,
 		"newline-before-return": false,
 		"newline-per-chained-call": false,
-		"no-angle-bracket-type-assertion": false,
 		"no-bitwise": false,
 		"no-console": false,
 		"no-default-export": false,


### PR DESCRIPTION
Since angle bracket type assertions were replaced by the `as` syntax, it's probably a good idea to use this instead. See also the [rationale on the lint page](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/).