### PR TITLE
skip files in typesVersions subdirectories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
 import { readdir, readFile, stat } from "fs-extra";
 import { basename, dirname, join as joinPaths } from "path";
@@ -160,7 +159,7 @@ async function testTypesVersion(
 	await checkTsconfig(dirPath, dt
 		? { relativeBaseUrl: ".." + (isOlderVersion ? "/.." : "") + (inTypesVersionDirectory ? "/.." : "") + "/" }
 		: undefined);
-	const err = await lint(dirPath, minVersion, maxVersion);
+	const err = await lint(dirPath, minVersion, maxVersion, !!inTypesVersionDirectory);
 	if (err) {
 		throw new Error(err);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
 import { readdir, readFile, stat } from "fs-extra";
 import { basename, dirname, join as joinPaths } from "path";


### PR DESCRIPTION
The main lint run should not lint files in typesVersions subdirectories. That's taken care of in a subsequent call to `lint`.