### PR TITLE
if `onlyTestTsNext` is set to true only install the "next" typescript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { readdir, readFile, stat } from "fs-extra";
 import { basename, dirname, join as joinPaths } from "path";
 
 import { checkPackageJson, checkTsconfig } from "./checks";
-import { cleanInstalls, installAll } from "./installer";
+import { cleanInstalls, installAll, installNext } from "./installer";
 import { checkTslintJson, lint, TsVersion } from "./lint";
 import { assertDefined, last, mapDefinedAsync, withoutPrefix } from "./util";
 
@@ -57,7 +57,13 @@ async function main(): Promise<void> {
 		// Do this *after* to ensure messages sent during installation aren't dropped.
 		await installAll();
 	} else {
-		await installAll();
+		if (!onlyTestTsNext) {
+			await installAll();
+		} else {
+			// if `onlyTestTsNext` is true we only need to install the next typescript version
+			// not all of them
+			await installNext();
+		}
 		await runTests(dirPath, onlyTestTsNext);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,10 @@ async function main(): Promise<void> {
 		// Do this *after* to ensure messages sent during installation aren't dropped.
 		await installAll();
 	} else {
-		if (!onlyTestTsNext) {
-			await installAll();
-		} else {
-			// if `onlyTestTsNext` is true we only need to install the next typescript version
-			// not all of them
+		if (onlyTestTsNext) {
 			await installNext();
+		} else {
+			await installAll();
 		}
 		await runTests(dirPath, onlyTestTsNext);
 	}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,6 +10,10 @@ export async function installAll() {
 	for (const v of TypeScriptVersion.all) {
 		await install(v);
 	}
+	await installNext();
+}
+
+export async function installNext() {
 	await install("next");
 }
 


### PR DESCRIPTION
At the moment if you supply `--onlyTestTsNext` it still installs **all** the typescript packages when it only needs to install the `next` one. 

This fixes this.

Can we merge this in ASAP please 👍 