### PR TITLE
Upgrade tslint to 5.12.0 and disable some rules

### DIFF
--- a/dtslint.json
+++ b/dtslint.json
@@ -72,7 +72,6 @@
 		"prefer-method-signature": false, // TODO?
 
 		// Pretty sure we don't want these
-		"ban-ts-ignore": false,
 		"binary-expression-operand-order": false,
 		"class-name": false,
 		"completed-docs": false,

--- a/dtslint.json
+++ b/dtslint.json
@@ -72,6 +72,7 @@
 		"prefer-method-signature": false, // TODO?
 
 		// Pretty sure we don't want these
+		"ban-ts-ignore": false,
 		"binary-expression-operand-order": false,
 		"class-name": false,
 		"completed-docs": false,
@@ -80,6 +81,7 @@
 		"deprecation": false,
 		"file-name-casing": false,
 		"forin": false,
+		"increment-decrement": false,
 		"indent": false,
 		"match-default-export-name": false,
 		"max-classes-per-file": false,
@@ -90,6 +92,7 @@
 		"no-bitwise": false,
 		"no-console": false,
 		"no-default-export": false,
+		"no-default-import": false,
 		"no-empty": false,
 		"no-implicit-dependencies": false, // See https://github.com/palantir/tslint/issues/3364
 		"no-inferred-empty-object-type": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -284,7 +284,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
@@ -293,11 +293,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "semver": {
@@ -307,7 +307,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "strip-ansi": {
@@ -334,9 +334,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.0.tgz",
+      "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -361,9 +361,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+      "version": "3.3.0-dev.20181218",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.0-dev.20181218.tgz",
+      "integrity": "sha512-3UkemHFrD3IIoYvcjUCVbhFK+Sf3PTT5uuRJYeorncPChHHWvH8O+aSm8pG5/glBHhKcznhXDRaY0RtCWR1sLA=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
     "fs-extra": "^6.0.1",
     "strip-json-comments": "^2.0.1",
-    "tslint": "^5.9.1",
+    "tslint": "^5.12.0",
     "typescript": "next"
   },
   "devDependencies": {


### PR DESCRIPTION
Originally I was going to create a PR only to disable the rule `increment-decrement` since I don't believe it adds anything to the consistency or quality of definition tests (and shouldn't matter in definitions), but when I realized that this specific rule is just recently added, I took a look at the other rules and tried to apply them too. 

### [tslint v5.12.0](https://github.com/palantir/tslint/releases/tag/5.12.0)

##### New Rules
* [`ban-ts-ignore`](https://palantir.github.io/tslint/rules/ban-ts-ignore/)
  - Enabled. No file in `DefinitelyTyped` contains `@ts-ignore` , typescript errors are alowed with dtslint and there's really no need to supress a typescript type error. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L42))

* [`function-constructor`](https://palantir.github.io/tslint/rules/function-constructor/)
  - Enabled. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L42))

* [`increment-decrement`](https://palantir.github.io/tslint/rules/increment-decrement/)
  - [Disabled](https://github.com/Microsoft/dtslint/pull/171/commits/6132ba4fef92141af2fc37a391618f00bfc3a014#diff-7089ff0805a8434e3f8939ec988cfd82R84). While there isn't really any reason for using 
`a++` operators in tests, some tests (in DefinitelyTyped) uses reallife code snippets whch can contain them. Causing [some errors](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/469496167#L3371-L3384) in big libs in DefinitelyTyped already. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L197))

* [`no-default-import`](https://palantir.github.io/tslint/rules/no-default-import/)
  - [Disabled](https://github.com/Microsoft/dtslint/pull/171/commits/6132ba4fef92141af2fc37a391618f00bfc3a014#diff-7089ff0805a8434e3f8939ec988cfd82R95).  ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L162))

* [`unnecessary-constructor`](https://palantir.github.io/tslint/rules/unnecessary-constructor/)
  - Enabled. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L148)

* [`comment-type`](https://palantir.github.io/tslint/rules/comment-type/)
  - Enabled. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L190))

* [`unnecessary-bind`](https://palantir.github.io/tslint/rules/unnecessary-bind/)
  - Enabled. ([Default](https://github.com/palantir/tslint/blob/5.12.0/src/configs/all.ts#L257))