### PR TITLE
Programmatic apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-bin
 node_modules
 typescript-installs
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -361,9 +361,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+      "version": "3.3.0-dev.20181218",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.0-dev.20181218.tgz",
+      "integrity": "sha512-3UkemHFrD3IIoYvcjUCVbhFK+Sf3PTT5uuRJYeorncPChHHWvH8O+aSm8pG5/glBHhKcznhXDRaY0RtCWR1sLA=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "dt.json",
     "dtslint.json"
   ],
-  "main": "bin",
-  "bin": "./bin/index.js",
+  "main": "dist",
+  "bin": "./dist/bin/index.js",
   "contributors": [
     "Andy Hanson <andy-ms@microsoft.com> (https://github.com/andy-ms)",
     "Dan Vanderkam <danvdk@gmail.com> (https://github.com/danvk)"

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -3,10 +3,10 @@ import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } fr
 import { readdir, readFile, stat } from "fs-extra";
 import { basename, dirname, join as joinPaths } from "path";
 
-import { checkPackageJson, checkTsconfig } from "./checks";
-import { cleanInstalls, installAll } from "./installer";
-import { checkTslintJson, lint, TsVersion } from "./lint";
-import { assertDefined, last, mapDefinedAsync, withoutPrefix } from "./util";
+import { checkPackageJson, checkTsconfig } from "../checks";
+import { cleanInstalls, installAll } from "../installer";
+import { checkTslintJson, lint, TsVersion } from "../lint";
+import { assertDefined, last, mapDefinedAsync, withoutPrefix } from "../util";
 
 async function main(): Promise<void> {
 	const args = process.argv.slice(2);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,12 +1,7 @@
 #!/usr/bin/env node
-import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
-import { readdir, readFile, stat } from "fs-extra";
-import { basename, dirname, join as joinPaths } from "path";
+import { join as joinPaths } from "path";
 
-import { checkPackageJson, checkTsconfig } from "../checks";
-import { cleanInstalls, installAll, installNext } from "../installer";
-import { checkTslintJson, lint, TsVersion } from "../lint";
-import { assertDefined, last, mapDefinedAsync, withoutPrefix } from "../util";
+import { cleanInstalls, installAll, installNext, runTests } from "../";
 
 async function main(): Promise<void> {
 	const args = process.argv.slice(2);
@@ -84,115 +79,6 @@ function listen(dirPath: string): void {
 			})
 			.catch(e => console.error(e.stack));
 	});
-}
-
-async function runTests(dirPath: string, onlyTestTsNext: boolean): Promise<void> {
-	const isOlderVersion = /^v\d+$/.test(basename(dirPath));
-
-	const indexText = await readFile(joinPaths(dirPath, "index.d.ts"), "utf-8");
-	// If this *is* on DefinitelyTyped, types-publisher will fail if it can't parse the header.
-	const dt = indexText.includes("// Type definitions for");
-	if (dt) {
-		// Someone may have copied text from DefinitelyTyped to their type definition and included a header,
-		// so assert that we're really on DefinitelyTyped.
-		assertPathIsInDefinitelyTyped(dirPath);
-	}
-
-	const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {
-		if (name === "tsconfig.json" || name === "tslint.json" || name === "tsutils") { return undefined; }
-		const version = withoutPrefix(name, "ts");
-		if (version === undefined || !(await stat(joinPaths(dirPath, name))).isDirectory()) { return undefined; }
-
-		if (!isTypeScriptVersion(version)) {
-			throw new Error(`There is an entry named ${name}, but ${version} is not a valid TypeScript version.`);
-		}
-		if (!TypeScriptVersion.isRedirectable(version)) {
-			throw new Error(`At ${dirPath}/${name}: TypeScript version directories only available starting with ts3.1.`);
-		}
-		return version;
-	});
-
-	if (dt) {
-		await checkPackageJson(dirPath, typesVersions);
-	}
-
-	if (onlyTestTsNext) {
-		if (typesVersions.length === 0) {
-			await testTypesVersion(dirPath, "next", "next", isOlderVersion, dt, indexText);
-		} else {
-			const latestTypesVersion = last(typesVersions);
-			const versionPath = joinPaths(dirPath, `ts${latestTypesVersion}`);
-			const versionIndexText = await readFile(joinPaths(versionPath, "index.d.ts"), "utf-8");
-			await testTypesVersion(versionPath, "next", "next", isOlderVersion, dt, versionIndexText);
-		}
-	} else {
-		await testTypesVersion(dirPath, undefined, getTsVersion(0), isOlderVersion, dt, indexText);
-		for (let i = 0; i < typesVersions.length; i++) {
-			const version = typesVersions[i];
-			const versionPath = joinPaths(dirPath, `ts${version}`);
-			const versionIndexText = await readFile(joinPaths(versionPath, "index.d.ts"), "utf-8");
-			await testTypesVersion(
-				versionPath, version, getTsVersion(i + 1), isOlderVersion, dt, versionIndexText,
-				/*inTypesVersionDirectory*/ true);
-		}
-
-		function getTsVersion(i: number): TsVersion {
-			return i === typesVersions.length ? "next" : assertDefined(TypeScriptVersion.previous(typesVersions[i]));
-		}
-	}
-}
-
-async function testTypesVersion(
-	dirPath: string,
-	lowVersion: TsVersion | undefined,
-	maxVersion: TsVersion,
-	isOlderVersion: boolean,
-	dt: boolean,
-	indexText: string,
-	inTypesVersionDirectory?: boolean,
-): Promise<void> {
-	const minVersionFromComment = getTypeScriptVersionFromComment(indexText);
-	if (minVersionFromComment !== undefined && inTypesVersionDirectory) {
-		throw new Error(`Already in the \`ts${lowVersion}\` directory, don't need \`// TypeScript Version\`.`);
-	}
-	if (minVersionFromComment !== undefined && TypeScriptVersion.isRedirectable(minVersionFromComment)) {
-		throw new Error(`Don't use \`// TypeScript Version\` for newer TS versions, use typesVerisons instead.`);
-	}
-	const minVersion = lowVersion || minVersionFromComment || TypeScriptVersion.lowest;
-
-	await checkTslintJson(dirPath, dt);
-	await checkTsconfig(dirPath, dt
-		? { relativeBaseUrl: ".." + (isOlderVersion ? "/.." : "") + (inTypesVersionDirectory ? "/.." : "") + "/" }
-		: undefined);
-	const err = await lint(dirPath, minVersion, maxVersion, !!inTypesVersionDirectory);
-	if (err) {
-		throw new Error(err);
-	}
-}
-
-function assertPathIsInDefinitelyTyped(dirPath: string): void {
-	const parent = dirname(dirPath);
-	const types = /^v\d+$/.test(basename(dirPath)) ? dirname(parent) : parent;
-	const dt = dirname(types);
-	if (basename(dt) !== "DefinitelyTyped" || basename(types) !== "types") {
-		throw new Error("Since this type definition includes a header (a comment starting with `// Type definitions for`), "
-			+ "assumed this was a DefinitelyTyped package.\n"
-			+ "But it is not in a `DefinitelyTyped/types/xxx` directory.");
-	}
-}
-
-function getTypeScriptVersionFromComment(text: string): TypeScriptVersion | undefined {
-	const searchString = "// TypeScript Version: ";
-	const x = text.indexOf(searchString);
-	if (x === -1) {
-		return undefined;
-	}
-
-	let line = text.slice(x, text.indexOf("\n", x));
-	if (line.endsWith("\r")) {
-		line = line.slice(0, line.length - 1);
-	}
-	return parseTypeScriptVersionLine(line);
 }
 
 if (!module.parent) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
+import { readdir, readFile, stat } from "fs-extra";
+import { basename, dirname, join as joinPaths } from "path";
+
+import { checkPackageJson, checkTsconfig } from "./checks";
+import { checkTslintJson, lint, TsVersion } from "./lint";
+import { assertDefined, last, mapDefinedAsync, withoutPrefix } from "./util";
+
+export { cleanInstalls, installAll, installNext } from "./installer";
+
+export async function runTests(dirPath: string, onlyTestTsNext: boolean): Promise<void> {
+	const isOlderVersion = /^v\d+$/.test(basename(dirPath));
+
+	const indexText = await readFile(joinPaths(dirPath, "index.d.ts"), "utf-8");
+	// If this *is* on DefinitelyTyped, types-publisher will fail if it can't parse the header.
+	const dt = indexText.includes("// Type definitions for");
+	if (dt) {
+		// Someone may have copied text from DefinitelyTyped to their type definition and included a header,
+		// so assert that we're really on DefinitelyTyped.
+		assertPathIsInDefinitelyTyped(dirPath);
+	}
+
+	const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {
+		if (name === "tsconfig.json" || name === "tslint.json" || name === "tsutils") { return undefined; }
+		const version = withoutPrefix(name, "ts");
+		if (version === undefined || !(await stat(joinPaths(dirPath, name))).isDirectory()) { return undefined; }
+
+		if (!isTypeScriptVersion(version)) {
+			throw new Error(`There is an entry named ${name}, but ${version} is not a valid TypeScript version.`);
+		}
+		if (!TypeScriptVersion.isRedirectable(version)) {
+			throw new Error(`At ${dirPath}/${name}: TypeScript version directories only available starting with ts3.1.`);
+		}
+		return version;
+	});
+
+	if (dt) {
+		await checkPackageJson(dirPath, typesVersions);
+	}
+
+	if (onlyTestTsNext) {
+		if (typesVersions.length === 0) {
+			await testTypesVersion(dirPath, "next", "next", isOlderVersion, dt, indexText);
+		} else {
+			const latestTypesVersion = last(typesVersions);
+			const versionPath = joinPaths(dirPath, `ts${latestTypesVersion}`);
+			const versionIndexText = await readFile(joinPaths(versionPath, "index.d.ts"), "utf-8");
+			await testTypesVersion(versionPath, "next", "next", isOlderVersion, dt, versionIndexText);
+		}
+	} else {
+		await testTypesVersion(dirPath, undefined, getTsVersion(0), isOlderVersion, dt, indexText);
+		for (let i = 0; i < typesVersions.length; i++) {
+			const version = typesVersions[i];
+			const versionPath = joinPaths(dirPath, `ts${version}`);
+			const versionIndexText = await readFile(joinPaths(versionPath, "index.d.ts"), "utf-8");
+			await testTypesVersion(
+				versionPath, version, getTsVersion(i + 1), isOlderVersion, dt, versionIndexText,
+				/*inTypesVersionDirectory*/ true);
+		}
+
+		function getTsVersion(i: number): TsVersion {
+			return i === typesVersions.length ? "next" : assertDefined(TypeScriptVersion.previous(typesVersions[i]));
+		}
+	}
+}
+
+async function testTypesVersion(
+	dirPath: string,
+	lowVersion: TsVersion | undefined,
+	maxVersion: TsVersion,
+	isOlderVersion: boolean,
+	dt: boolean,
+	indexText: string,
+	inTypesVersionDirectory?: boolean,
+): Promise<void> {
+	const minVersionFromComment = getTypeScriptVersionFromComment(indexText);
+	if (minVersionFromComment !== undefined && inTypesVersionDirectory) {
+		throw new Error(`Already in the \`ts${lowVersion}\` directory, don't need \`// TypeScript Version\`.`);
+	}
+	if (minVersionFromComment !== undefined && TypeScriptVersion.isRedirectable(minVersionFromComment)) {
+		throw new Error(`Don't use \`// TypeScript Version\` for newer TS versions, use typesVerisons instead.`);
+	}
+	const minVersion = lowVersion || minVersionFromComment || TypeScriptVersion.lowest;
+
+	await checkTslintJson(dirPath, dt);
+	await checkTsconfig(dirPath, dt
+		? { relativeBaseUrl: ".." + (isOlderVersion ? "/.." : "") + (inTypesVersionDirectory ? "/.." : "") + "/" }
+		: undefined);
+	const err = await lint(dirPath, minVersion, maxVersion, !!inTypesVersionDirectory);
+	if (err) {
+		throw new Error(err);
+	}
+}
+
+function assertPathIsInDefinitelyTyped(dirPath: string): void {
+	const parent = dirname(dirPath);
+	const types = /^v\d+$/.test(basename(dirPath)) ? dirname(parent) : parent;
+	const dt = dirname(types);
+	if (basename(dt) !== "DefinitelyTyped" || basename(types) !== "types") {
+		throw new Error("Since this type definition includes a header (a comment starting with `// Type definitions for`), "
+			+ "assumed this was a DefinitelyTyped package.\n"
+			+ "But it is not in a `DefinitelyTyped/types/xxx` directory.");
+	}
+}
+
+function getTypeScriptVersionFromComment(text: string): TypeScriptVersion | undefined {
+	const searchString = "// TypeScript Version: ";
+	const x = text.indexOf(searchString);
+	if (x === -1) {
+		return undefined;
+	}
+
+	let line = text.slice(x, text.indexOf("\n", x));
+	if (line.endsWith("\r")) {
+		line = line.slice(0, line.length - 1);
+	}
+	return parseTypeScriptVersionLine(line);
+}

--- a/test/dt-header/correct/tslint.json
+++ b/test/dt-header/correct/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../../bin/rules"],
+  "rulesDirectory": ["../../../dist/rules"],
   "rules": {
     "dt-header": true
   }

--- a/test/dt-header/wrong/tslint.json
+++ b/test/dt-header/wrong/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../../bin/rules"],
+  "rulesDirectory": ["../../../dist/rules"],
   "rules": {
     "dt-header": true
   }

--- a/test/expect/tslint.json
+++ b/test/expect/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "expect": true
   }

--- a/test/export-just-namespace/tslint.json
+++ b/test/export-just-namespace/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "export-just-namespace": true
   }

--- a/test/no-any-union/tslint.json
+++ b/test/no-any-union/tslint.json
@@ -1,5 +1,5 @@
 {
-    "rulesDirectory": ["../../bin/rules"],
+    "rulesDirectory": ["../../dist/rules"],
     "rules": {
       "no-any-union": true
     }

--- a/test/no-bad-reference/tslint.json
+++ b/test/no-bad-reference/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-bad-reference": true
   }

--- a/test/no-const-enum/tslint.json
+++ b/test/no-const-enum/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-const-enum": true
   }

--- a/test/no-dead-reference/tslint.json
+++ b/test/no-dead-reference/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-dead-reference": true
   }

--- a/test/no-import-default-of-export-equals/bad-ambient-modules/tslint.json
+++ b/test/no-import-default-of-export-equals/bad-ambient-modules/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../../bin/rules"],
+  "rulesDirectory": ["../../../dist/rules"],
   "rules": {
     "no-import-default-of-export-equals": true
   }

--- a/test/no-import-default-of-export-equals/bad-external-modules/tslint.json
+++ b/test/no-import-default-of-export-equals/bad-external-modules/tslint.json
@@ -1,7 +1,6 @@
 {
-    "rulesDirectory": ["../../../bin/rules"],
+    "rulesDirectory": ["../../../dist/rules"],
     "rules": {
       "no-import-default-of-export-equals": true
     }
   }
-  

--- a/test/no-import-default-of-export-equals/good-ambient-modules/tslint.json
+++ b/test/no-import-default-of-export-equals/good-ambient-modules/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../../bin/rules"],
+  "rulesDirectory": ["../../../dist/rules"],
   "rules": {
     "no-import-default-of-export-equals": true
   }

--- a/test/no-padding/tslint.json
+++ b/test/no-padding/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-padding": true
   }

--- a/test/no-redundant-undefined/tslint.json
+++ b/test/no-redundant-undefined/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-redundant-undefined": true
   }

--- a/test/no-relative-import-in-test/tslint.json
+++ b/test/no-relative-import-in-test/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-relative-import-in-test": true
   }

--- a/test/no-single-declare-module/tslint.json
+++ b/test/no-single-declare-module/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-single-declare-module": true
   }

--- a/test/no-single-element-tuple-type/tslint.json
+++ b/test/no-single-element-tuple-type/tslint.json
@@ -1,5 +1,5 @@
 {
-    "rulesDirectory": ["../../bin/rules"],
+    "rulesDirectory": ["../../dist/rules"],
     "rules": {
       "no-single-element-tuple-type": true
     }

--- a/test/no-unnecessary-generics/tslint.json
+++ b/test/no-unnecessary-generics/tslint.json
@@ -1,5 +1,5 @@
 {
-    "rulesDirectory": ["../../bin/rules"],
+    "rulesDirectory": ["../../dist/rules"],
     "rules": {
         "no-unnecessary-generics": true
     }

--- a/test/no-useless-files/tslint.json
+++ b/test/no-useless-files/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "no-useless-files": true
   }

--- a/test/prefer-declare-function/tslint.json
+++ b/test/prefer-declare-function/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "prefer-declare-function": true
   }

--- a/test/strict-export-declare-modifiers/tslint.json
+++ b/test/strict-export-declare-modifiers/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "strict-export-declare-modifiers": true
   }

--- a/test/trim-file/tslint.json
+++ b/test/trim-file/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "trim-file": true
   }

--- a/test/void-return/tslint.json
+++ b/test/void-return/tslint.json
@@ -1,5 +1,5 @@
 {
-  "rulesDirectory": ["../../bin/rules"],
+  "rulesDirectory": ["../../dist/rules"],
   "rules": {
     "void-return": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"module": "commonjs",
 		"target": "es6",
 		"lib": ["es2017"],
-		"outDir": "bin",
+		"outDir": "dist",
 		"sourceMap": true,
 		"newLine": "lf",
 


### PR DESCRIPTION
Fixes #165

- Modify outDir(`bin` => `dist` and `bin/index.js` => `dist/bin/index.js`)
- Expose `cleanInstalls`, `installAll`, `installNext` and `runTests`