### PR TITLE
Respect extends in tslint.json

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -114,6 +114,9 @@ function testNoTslintDisables(text: string): Err | undefined {
 export async function checkTslintJson(dirPath: string, dt: boolean): Promise<void> {
     const configPath = getConfigPath(dirPath);
     const shouldExtend = `dtslint/${dt ? "dt" : "dtslint"}.json`;
+    const validateExtends = (extend: string | string[]) =>
+        extend === shouldExtend || (!dt && Array.isArray(extend) && extend.some(val => val === shouldExtend));
+
     if (!await pathExists(configPath)) {
         if (dt) {
             throw new Error(
@@ -124,7 +127,7 @@ export async function checkTslintJson(dirPath: string, dt: boolean): Promise<voi
     }
 
     const tslintJson = await readJson(configPath);
-    if (tslintJson.extends !== shouldExtend) {
+    if (!validateExtends(tslintJson.extends)) {
         throw new Error(`If 'tslint.json' is present, it should extend "${shouldExtend}"`);
     }
 }


### PR DESCRIPTION
With `dtslint` setup on private types repo one thing caused my a lot of frustration before I looked up the source code - tslint extends does not allow array value, even only with one element.

It's non-intuitive and for me personally `tslint-config-prettier` is a must :)

```json5
// tslint.json
{
 // This is fine
  "extends": "dtslint/dtslint.json",
}
```

```json5
{
 // This is not, and it probably should
  "extends": ["dtslint/dtslint.json"],
}
```

```json5
{
 // This is also not, and probably should be allowed for non-DefinitelyTyped users
  "extends": ["dtslint/dtslint.json", "tslint-config-prettier"],
}
```

Well, why not enable it? 6 lines of code, works for me :smirk:  : 

It may be prudent to lock this feature for `dt = true`, just in case. Let me know I can update it.
