### PR TITLE
Let '$ExpectType ReadonlyArray<T>' match 'readonly T[]'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -361,9 +361,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.0-dev.20181218",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.0-dev.20181218.tgz",
-      "integrity": "sha512-3UkemHFrD3IIoYvcjUCVbhFK+Sf3PTT5uuRJYeorncPChHHWvH8O+aSm8pG5/glBHhKcznhXDRaY0RtCWR1sLA=="
+      "version": "3.4.0-dev.20190206",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.0-dev.20190206.tgz",
+      "integrity": "sha512-BTIrNeDlJlEy0hEmyLR6Dw7umjjgnCDgYpsBT+xVWfRsaybh7Q1tejjxVazhpQf4ev48ixGwWb0v1v/WMT5ITw=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/test/expect/expectType.ts.lint
+++ b/test/expect/expectType.ts.lint
@@ -25,3 +25,6 @@ f; // $ExpectType (one: number, two: [number, number], three: [number, number, n
 // Test that we get the type of the initializer on a variable declaration.
 // $ExpectType 1
 const x = 1;
+
+declare const ar: readonly number[];
+ar; // $ExpectType ReadonlyArray<number>


### PR DESCRIPTION
This lets `// $ExpectType ReadonlyArray<T>` match `readonly T[]` for arbitrarily nested instances of `readonly T[]`. 