### PR TITLE
Exempt existing packages from 'download' forbidden word

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach",
+            "port": 9229,
+            "sourceMaps": true
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${file}"
+        }
+    ]
+}

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -17,7 +17,10 @@ export async function checkPackageJson(
         }
         return;
     }
-    if (/download/.test(dirPath)) {
+    if (/download/.test(dirPath) &&
+        dirPath !== "download" &&
+        dirPath !== "downloadjs" &&
+        dirPath !== "s3-download-stream") {
         // Since npm won't release their banned-words list, we'll have to manually add to this list.
         throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);
     }


### PR DESCRIPTION
Definitely Typed already has 3 existing packages that have 'download' in the name. Allow these names.

cc @SimonSchick 