### PR TITLE
add --localTs flag: run with locally built TS

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,3 +1,4 @@
+import assert = require("assert");
 import { exec } from "child_process";
 import { TypeScriptVersion } from "definitelytyped-header-parser";
 import * as fs from "fs-extra";
@@ -22,6 +23,9 @@ export async function installNext() {
 }
 
 async function install(version: TsVersion): Promise<void> {
+    if (version === "local") {
+        return;
+    }
     const dir = installDir(version);
     if (!await fs.pathExists(dir)) {
         console.log(`Installing to ${dir}...`);
@@ -36,11 +40,15 @@ export function cleanInstalls(): Promise<void> {
     return fs.remove(installsDir);
 }
 
-export function typeScriptPath(version: TsVersion): string {
+export function typeScriptPath(version: TsVersion, tsLocal: string | undefined): string {
+    if (version === "local") {
+        return tsLocal! + "/typescript.js";
+    }
     return path.join(installDir(version), "node_modules", "typescript");
 }
 
 function installDir(version: TsVersion): string {
+    assert(version !== "local");
     return path.join(installsDir, version);
 }
 

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -17,12 +17,17 @@ export async function lint(
     minVersion: TsVersion,
     maxVersion: TsVersion,
     inTypesVersionDirectory: boolean,
-    expectOnly: boolean): Promise<string | undefined> {
+    expectOnly: boolean,
+    tsLocal: string | undefined): Promise<string | undefined> {
     const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
     const lintProgram = Linter.createProgram(tsconfigPath);
 
+    if (tsLocal) {
+        const errors = testDependencies("local", dirPath, lintProgram, tsLocal);
+        if (errors) { return errors; }
+    }
     for (const version of [maxVersion, minVersion]) {
-        const errors = testDependencies(version, dirPath, lintProgram);
+        const errors = testDependencies(version, dirPath, lintProgram, tsLocal);
         if (errors) { return errors; }
     }
 
@@ -32,7 +37,7 @@ export async function lint(
     };
     const linter = new Linter(lintOptions, lintProgram);
     const configPath = expectOnly ? joinPaths(__dirname, "..", "dtslint-expect-only.json") : getConfigPath(dirPath);
-    const config = await getLintConfig(configPath, tsconfigPath, minVersion, maxVersion);
+    const config = await getLintConfig(configPath, tsconfigPath, minVersion, maxVersion, tsLocal);
 
     for (const file of lintProgram.getSourceFiles()) {
         if (lintProgram.isSourceFileDefaultLibrary(file)) { continue; }
@@ -57,9 +62,10 @@ export async function lint(
     return result.failures.length ? result.output : undefined;
 }
 
-function testDependencies(version: TsVersion, dirPath: string, lintProgram: TsType.Program): string | undefined {
+function testDependencies(version: TsVersion, dirPath: string, lintProgram: TsType.Program, tsLocal: string | undefined): string | undefined {
     const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
-    const ts: typeof TsType = require(typeScriptPath(version));
+    assert(version !== "local" || tsLocal);
+    const ts: typeof TsType = require(typeScriptPath(version, tsLocal));
     const program = getProgram(tsconfigPath, ts, version, lintProgram);
     const diagnostics = ts.getPreEmitDiagnostics(program).filter(d => !d.file || isExternalDependency(d.file, dirPath, program));
     if (!diagnostics.length) { return undefined; }
@@ -143,6 +149,7 @@ async function getLintConfig(
     tsconfigPath: string,
     minVersion: TsVersion,
     maxVersion: TsVersion,
+    tsLocal: string | undefined
 ): Promise<IConfigurationFile> {
     const configExists = await pathExists(expectedConfigPath);
     const configPath = configExists ? expectedConfigPath : joinPaths(__dirname, "..", "dtslint.json");
@@ -157,8 +164,8 @@ async function getLintConfig(
         throw new Error("'expect' rule should be enabled, else compile errors are ignored");
     }
     if (expectRule) {
-        const versionsToTest = range(minVersion, maxVersion).map(versionName =>
-            ({ versionName, path: typeScriptPath(versionName) }));
+        const versionsToTest =
+            range(minVersion, maxVersion).map(versionName => ({ versionName, path: typeScriptPath(versionName, tsLocal) }));
         const expectOptions: ExpectOptions = { tsconfigPath, versionsToTest };
         expectRule.ruleArguments = [expectOptions];
     }
@@ -169,6 +176,10 @@ function range(minVersion: TsVersion, maxVersion: TsVersion): ReadonlyArray<TsVe
     if (minVersion === "next") {
         assert(maxVersion === "next");
         return ["next"];
+    }
+    if (minVersion === "local") {
+        assert(maxVersion === "local");
+        return ["local"];
     }
 
     // The last item of TypeScriptVersion is the unreleased version of Typescript,
@@ -182,4 +193,4 @@ function range(minVersion: TsVersion, maxVersion: TsVersion): ReadonlyArray<TsVe
     return allReleased.slice(minIdx, maxIdx + 1);
 }
 
-export type TsVersion = TypeScriptVersion | "next";
+export type TsVersion = TypeScriptVersion | "next" | "local";

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -22,10 +22,6 @@ export async function lint(
     const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
     const lintProgram = Linter.createProgram(tsconfigPath);
 
-    if (tsLocal) {
-        const errors = testDependencies("local", dirPath, lintProgram, tsLocal);
-        if (errors) { return errors; }
-    }
     for (const version of [maxVersion, minVersion]) {
         const errors = testDependencies(version, dirPath, lintProgram, tsLocal);
         if (errors) { return errors; }


### PR DESCRIPTION
eg

```
$ dtslint --localTs ~/ts/built/local types jsqrcode
```

Like --onlyTestTsNext, this only tests with one version of Typescript.