### PR TITLE
Allow `export declare` in test (.ts) files

### DIFF
--- a/src/rules/strictExportDeclareModifiersRule.ts
+++ b/src/rules/strictExportDeclareModifiersRule.ts
@@ -29,7 +29,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
     for (const node of sourceFile.statements) {
         if (isExternal) {
             checkInExternalModule(node, isAutomaticExport(sourceFile));
-        } else {
+        } else if (sourceFile.isDeclarationFile) {
             checkInOther(node);
         }
 

--- a/src/rules/strictExportDeclareModifiersRule.ts
+++ b/src/rules/strictExportDeclareModifiersRule.ts
@@ -29,8 +29,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
     for (const node of sourceFile.statements) {
         if (isExternal) {
             checkInExternalModule(node, isAutomaticExport(sourceFile));
-        } else if (sourceFile.isDeclarationFile) {
-            checkInOther(node);
+        } else {
+            checkInOther(node, sourceFile.isDeclarationFile);
         }
 
         if (isModuleDeclaration(node) && (sourceFile.isDeclarationFile || isDeclare(node))) {
@@ -64,10 +64,10 @@ function walk(ctx: Lint.WalkContext<void>): void {
         }
     }
 
-    function checkInOther(node: ts.Statement): void {
+    function checkInOther(node: ts.Statement, inDeclarationFile: boolean): void {
         // Compiler will enforce presence of 'declare' where necessary. But types do not need 'declare'.
         if (isDeclare(node)) {
-            if (isExport(node) ||
+            if (isExport(node) && inDeclarationFile ||
                 node.kind === ts.SyntaxKind.InterfaceDeclaration ||
                 node.kind === ts.SyntaxKind.TypeAliasDeclaration) {
                 fail(mod(node, ts.SyntaxKind.DeclareKeyword), "'declare' keyword is redundant here.");

--- a/test/strict-export-declare-modifiers/testModuleTs.ts.lint
+++ b/test/strict-export-declare-modifiers/testModuleTs.ts.lint
@@ -1,3 +1,5 @@
+export declare class C {}
+
 export function f() {}
 
 declare interface I {}


### PR DESCRIPTION
It's only redundant in d.ts files

Fixes #209