### PR TITLE
Skip npm-naming rule on old versions

### DIFF
--- a/src/rules/dtHeaderRule.ts
+++ b/src/rules/dtHeaderRule.ts
@@ -27,7 +27,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
             ctx.addFailureAt(idx, search.length, failure(Rule.metadata.ruleName, explanation));
         }
     };
-    if (!isMainFile(sourceFile.fileName)) {
+    if (!isMainFile(sourceFile.fileName, /*allowNested*/ true)) {
         lookFor("// Type definitions for", "Header should only be in `index.d.ts` of the root.");
         lookFor("// TypeScript Version", "TypeScript version should be specified under header in `index.d.ts`.");
         return;

--- a/src/rules/npmNamingRule.ts
+++ b/src/rules/npmNamingRule.ts
@@ -28,7 +28,7 @@ function walk(ctx: Lint.WalkContext<void>): void {
             ctx.addFailureAt(idx, search.length, failure(Rule.metadata.ruleName, explanation));
         }
     };
-    if (isMainFile(sourceFile.fileName)) {
+    if (isMainFile(sourceFile.fileName, /*allowNested*/ false)) {
         try {
             critic(sourceFile.fileName);
         } catch (e) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,7 +86,7 @@ export async function mapDefinedAsync<T, U>(arr: Iterable<T>, mapper: (t: T) => 
     return out;
 }
 
-export function isMainFile(fileName: string) {
+export function isMainFile(fileName: string, allowNested: boolean) {
     // Linter may be run with cwd of the package. We want `index.d.ts` but not `submodule/index.d.ts` to match.
     if (fileName === "index.d.ts") {
         return true;
@@ -99,7 +99,7 @@ export function isMainFile(fileName: string) {
     let parent = dirname(fileName);
     // May be a directory for an older version, e.g. `v0`.
     // Note a types redirect `foo/ts3.1` should not have its own header.
-    if (/^v\d+$/.test(basename(parent))) {
+    if (allowNested && /^v\d+$/.test(basename(parent))) {
         parent = dirname(parent);
     }
 


### PR DESCRIPTION
It's not necessary to keep those URLs up-to-date, and there are about 150 of them.