### PR TITLE
allow single-use constrained types in some situations

### DIFF
--- a/test/no-unnecessary-generics/test.ts.lint
+++ b/test/no-unnecessary-generics/test.ts.lint
@@ -34,5 +34,7 @@ function f<T, U extends T>(u: U): U;
 function foo<T>(m: Map<T, T>): void {}
 // `T` appears in a constraint, so it appears twice.
 function f<T, U extends T>(t: T, u: U): U;
+// `T` is used as inner type parameter
+function f<TX extends object>(t: Foo<TX>): void;
 
 [0]: Type parameter T is used only once. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md


### PR DESCRIPTION
Fixes #223.

What do you think of this? I'm not sure if its the cleanest way to go about it or the ideal place to do it, either, so some feedback on that would be nice.

It is to allow cases like this:

```ts
function func<T extends object>(param: Foo<T>): void;
```

This currently isn't allowed, but is of course a valid use case to constrain the type parameter.

cc @sandersn 