### PR TITLE
Log simple performance data from expect rule

### DIFF
--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -54,7 +54,6 @@ export class Rule extends Lint.Rules.TypedRule {
                         mkdirSync(perfDir);
                     }
                     writeFileSync(join(perfDir, `${packageName}.json`), JSON.stringify(d));
-                    console.log(JSON.stringify(d[packageName]));
                 }
             }
             return failures;

--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { dirname, basename, resolve as resolvePath } from "path";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { dirname, basename, resolve as resolvePath, join } from "path";
+import os = require("os");
 import * as Lint from "tslint";
 import * as TsType from "typescript";
 import { last } from "../util";
@@ -8,6 +9,8 @@ type Program = TsType.Program;
 type SourceFile = TsType.SourceFile;
 
 // Based on https://github.com/danvk/typings-checker
+
+const perfDir = join(os.homedir(), ".dts", "perf");
 
 export class Rule extends Lint.Rules.TypedRule {
     /* tslint:disable:object-literal-sort-keys */
@@ -47,7 +50,10 @@ export class Rule extends Lint.Rules.TypedRule {
                 const packageName = basename(dirname(tsconfigPath));
                 if (!packageName.match(/v\d+/) && !packageName.match(/ts\d\.\d/)) {
                     const d = { [packageName]: { typeCount: (program as any).getTypeCount(), memory: ts.sys.getMemoryUsage ? ts.sys.getMemoryUsage() : 0 } };
-                    writeFileSync(`./perf-${packageName}.json`, JSON.stringify(d));
+                    if (!existsSync(perfDir)) {
+                        mkdirSync(perfDir);
+                    }
+                    writeFileSync(join(perfDir, `${packageName}.json`), JSON.stringify(d));
                     console.log(JSON.stringify(d[packageName]));
                 }
             }


### PR DESCRIPTION
Write the data to a file with the same name in `~/.dts/perf/some-package-name.json`. Consumers can then read the file and display information from there. Note that tslint rules are not expected to write files, so perhaps there's a better way to log this information.

types-publisher and dtslint-runner need to be updated to display the data. Here's a simple script that runs on the output of dtslint-runner:

```js
const fs = require('fs');
const stats = require('stats-lite');
/** @type {Array<[string, number, number]>} */
let big = []
let types = []
for (const filename of fs.readdirSync('~/.dts/perf/', { encoding: "utf8" })) {
    /** @type {{ [s: string]: { typeCount: number, memory: number } }} */
    const x = JSON.parse(fs.readFileSync('~/.dts/perf/' + filename, { encoding: 'utf8' }))
    for (const k of Object.keys(x)) {
        big.push([k, x[k].typeCount])
        types.push(x[k].typeCount)
    }
}
console.log("{" + big.sort((a, b) => b[1] - a[1]).map(([name, count]) => ` "${name}": ${count}`).join(",") + "}")

console.log("99", stats.percentile(types, .99))
console.log("95", stats.percentile(types, .95))
console.log("90", stats.percentile(types, .90))
console.log("70", stats.percentile(types, .70))
console.log("50", stats.percentile(types, .50))
```

dtslint-runner can print this out or push the json to some data store. types-publisher needs an even smaller change in test-runner to look up and print the json files for each entry in changedPackages so that it shows up in the build output.