### PR TITLE
Resolve localTs path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { isTypeScriptVersion, parseTypeScriptVersionLine, TypeScriptVersion } from "definitelytyped-header-parser";
 import { readdir, readFile, stat } from "fs-extra";
-import { basename, dirname, join as joinPaths } from "path";
+import { basename, dirname, join as joinPaths, resolve } from "path";
 
 import { checkPackageJson, checkTsconfig } from "./checks";
 import { cleanInstalls, installAll, installNext } from "./installer";
@@ -23,7 +23,7 @@ async function main(): Promise<void> {
             if (arg.startsWith("--")) {
                 throw new Error("Looking for local path for TS, but got " + arg);
             }
-            tsLocal = arg;
+            tsLocal = resolve(arg);
             lookingForTsLocal = false;
             continue;
         }


### PR DESCRIPTION
This PR calls `resolve` on the argument supplied to the `localTs` command-line option - so that a path relative to the current directory can be passed.

ATM, it's necessary to pass an absolute path, as the dtslint implementation passes the supplied path to `require` in files within two different directories - so it's not possible to pass a relative path that works with both locations.

The need to pass an absolute path necessitated [some shenanigans in RxJS](https://github.com/ReactiveX/rxjs/pull/4712), where we use dtslint to test type declarations:

> The command must be passed an absolute path to the directory that contains typescript.js as said path is passed to require in two files within the dtslint implementation that reside in different directories - so each has a different relative path the the locally-installed TypeScript. To account for this, dtslint is now invoked via spec-dtslint/script.js.

This would be considerably simpler if a relative path could be passed.