### PR TITLE
Only check @ts-ignore, tslint:disable in *.d.ts

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -39,7 +39,8 @@ export async function lint(
         if (lintProgram.isSourceFileDefaultLibrary(file)) { continue; }
 
         const { fileName, text } = file;
-        const err = testNoTsIgnore(text) || testNoTslintDisables(text);
+        const err = isDeclarationFile(fileName) &&
+                    (testNoTsIgnore(text) || testNoTslintDisables(text));
         if (err) {
             const { pos, message } = err;
             const place = file.getLineAndCharacterOfPosition(pos);
@@ -86,6 +87,10 @@ function isExternalDependency(file: TsType.SourceFile, dirPath: string, program:
 function isTypesVersionPath(fileName: string, dirPath: string) {
     const subdirPath = withoutPrefix(fileName, dirPath);
     return subdirPath && /^\/ts\d+\.\d/.test(subdirPath);
+}
+
+function isDeclarationFile(fileName: string) {
+    return fileName.endsWith("d.ts");
 }
 
 function startsWithDirectory(filePath: string, dirPath: string): boolean {


### PR DESCRIPTION
[When writing tests for typechecking][1], included *.ts[x] files may contain `// @ts-ignore` comments. Thus dtslint will erroneously complain about their presence.

[Reading through why these checks got added][2], it seems that this change should be welcomed.

[1]: https://github.com/Microsoft/dtslint#write-tests
[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21446#issuecomment-344034873