### PR TITLE
package: pin typescript@^3.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "typescript": {
-      "version": "3.5.0-dev.20190424",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190424.tgz",
-      "integrity": "sha512-qjTuF/tIGS9RqvXxzz4XKr2TgzyKC457wtEHtEUhrUB2Kdb9HczrNOVQaFh1oNLLOBDHus3oqhzvYDxdLTnGBw=="
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "request": "^2.88.0",
     "strip-json-comments": "^2.0.1",
     "tslint": "5.14.0",
-    "typescript": "next"
+    "typescript": "^3.4.5"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.2",


### PR DESCRIPTION
Instead of depending on next ( which breaks dtslint )
We depend on a stable version.

This is necessary because a recent version from may of typescript@next breaks dtslint.

When I run `npm i dtslint` in my application ( outside of definitelytyped ) I get failures in the rules themselves.

```
The 'member-access' rule threw an error in '/home/raynos/projects/sync-wait-group/types/tape/index.d.ts':
TypeError: Cannot read property 'length' of undefined
    at recur (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/memberAccessRule.js:91:57)
    at visitNodes (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16630:30)
    at Object.forEachChild (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16858:24)
    at walk (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/memberAccessRule.js:89:15)
    at Rule.AbstractRule.applyWithFunction (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/language/rule/abstractRule.js:39:9)
    at Rule.apply (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/memberAccessRule.js:50:21)
    at Linter.applyRule (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/linter.js:214:29)
    at /home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/linter.js:155:85
    at Object.flatMap (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/utils.js:160:29)
    at Linter.getAllFailures (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/linter.js:155:32)
The 'no-unnecessary-class' rule threw an error in '/home/raynos/projects/sync-wait-group/types/tape/index.d.ts':
TypeError: Cannot read property 'length' of undefined
    at NoUnnecessaryClassWalker.checkMembers (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/noUnnecessaryClassRule.js:82:26)
    at checkIfUnnecessaryClass (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/noUnnecessaryClassRule.js:75:23)
    at visitNodes (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16630:30)
    at Object.forEachChild (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16858:24)
    at NoUnnecessaryClassWalker.walk (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/noUnnecessaryClassRule.js:79:12)
    at Rule.AbstractRule.applyWithWalker (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/language/rule/abstractRule.js:31:16)
    at Rule.apply (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/noUnnecessaryClassRule.js:39:21)
    at Linter.applyRule (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/linter.js:214:29)
    at /home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/linter.js:155:85
    at Object.flatMap (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/utils.js:160:29)
The 'interface-over-type-literal' rule threw an error in '/home/raynos/projects/sync-wait-group/types/tape/index.d.ts':
TypeError: Cannot read property 'kind' of undefined
    at Object.isTypeLiteralNode (/home/raynos/projects/sync-wait-group/node_modules/tsutils/typeguard/2.8/node.js:640:17)
    at cb (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/interfaceOverTypeLiteralRule.js:50:65)
    at visitNodes (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16630:30)
    at Object.forEachChild (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16856:24)
    at cb (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/interfaceOverTypeLiteralRule.js:64:19)
    at visitNode (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16621:24)
    at Object.forEachChild (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16957:21)
    at cb (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/tslint/lib/rules/interfaceOverTypeLiteralRule.js:64:19)
    at visitNodes (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16630:30)
    at Object.forEachChild (/home/raynos/projects/sync-wait-group/node_modules/dtslint/node_modules/typescript/lib/typescript.js:16858:24)
```