### PR TITLE
Fix banned words check and update dts-critic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -301,11 +301,11 @@
       "integrity": "sha1-0+PFQ/g29BA5RVuQNMcuNVsDYBk="
     },
     "dts-critic": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-1.0.9.tgz",
-      "integrity": "sha512-fUh7YSqC+usC0r4pnslxPr02XB9txKEvk/4drxAbSNx1CZDHSkpIAXlTSp6zAz1dBM09/qakRsAsr3r6zKNl2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-1.2.0.tgz",
+      "integrity": "sha512-z6VI1Sz7xxy0BgN6YsWuG9hbRIfph3U9hwrfNHLnLzsq865VYyjo5xKKUgXPuqMgJ04BUF1LGYQJ+kWyWwvUvQ==",
       "requires": {
-        "definitelytyped-header-parser": "^1.0.1",
+        "definitelytyped-header-parser": "^1.2.0",
         "download-file-sync": "^1.0.4",
         "yargs": "^12.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "definitelytyped-header-parser": "1.2.0",
-    "dts-critic": "^1.0.9",
+    "dts-critic": "^1.2.0",
     "fs-extra": "^6.0.1",
     "request": "^2.88.0",
     "strip-json-comments": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Runs tests on TypeScript definition files",
   "files": [
     "bin",

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,7 +1,7 @@
 import assert = require("assert");
 import { makeTypesVersionsForPackageJson, TypeScriptVersion } from "definitelytyped-header-parser";
 import { pathExists } from "fs-extra";
-import { basename, join as joinPaths } from "path";
+import { join as joinPaths } from "path";
 
 import { getCompilerOptions, readJson } from "./util";
 
@@ -16,14 +16,6 @@ export async function checkPackageJson(
             throw new Error(`${dirPath}: Must have 'package.json' for "typesVersions"`);
         }
         return;
-    }
-    const basedir = basename(dirPath);
-    if (/download/.test(basedir) &&
-        basedir !== "download" &&
-        basedir !== "downloadjs" &&
-        basedir !== "s3-download-stream") {
-        // Since npm won't release their banned-words list, we'll have to manually add to this list.
-        throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);
     }
 
     const pkgJson = await readJson(pkgJsonPath) as {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,7 @@ async function runTests(
         // Someone may have copied text from DefinitelyTyped to their type definition and included a header,
         // so assert that we're really on DefinitelyTyped.
         assertPathIsInDefinitelyTyped(dirPath);
+        assertPathIsNotBanned(dirPath);
     }
 
     const typesVersions = await mapDefinedAsync(await readdir(dirPath), async name => {
@@ -215,6 +216,17 @@ function assertPathIsInDefinitelyTyped(dirPath: string): void {
             + "assumed this was a DefinitelyTyped package.\n"
             + "But it is not in a `DefinitelyTyped/types/xxx` directory: "
             + dirPath);
+    }
+}
+
+function assertPathIsNotBanned(dirPath: string) {
+    const basedir = basename(dirPath);
+    if (/download/.test(basedir) &&
+        basedir !== "download" &&
+        basedir !== "downloadjs" &&
+        basedir !== "s3-download-stream") {
+        // Since npm won't release their banned-words list, we'll have to manually add to this list.
+        throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);
     }
 }
 

--- a/src/rules/npmNamingRule.ts
+++ b/src/rules/npmNamingRule.ts
@@ -39,8 +39,6 @@ function walk(ctx: Lint.WalkContext<void>): void {
             if (e.message.indexOf("d.ts file must have a matching npm package") > -1 ||
                 e.message.indexOf("The non-npm package") > -1) {
                 lookFor("// Type definitions for", e.message);
-            } else if (e.message.indexOf("At least one of the project urls listed") > -1) {
-                lookFor("// Project:", e.message);
             } else if (e.message.indexOf("export default") > -1) {
                 lookFor("export default", e.message);
             } else {


### PR DESCRIPTION
1. Update to dts-critic 1.2, which no longer requires project urls to include the homepage url specified on npm.
2. Check for banned words for all packages, not just those complex enough to have a package.json. The location of the check was wrong.