### PR TITLE
Update checks.ts

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -91,6 +91,7 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
                 case "target":
                 case "paths":
                 case "jsx":
+                case "jsxFactory":
                 case "experimentalDecorators":
                 case "noUnusedLocals":
                 case "noUnusedParameters":


### PR DESCRIPTION
Not all type definitions use `React.createElement` as the jsx pragma. I bumped into this issue when updating `storybook__preact` types as per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37275

By adding the compiler option `jsxFactory` other pragmas can be used in type definitions