### PR TITLE
Add documentation about localTs and expectOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ For bundled typings, this can go on any line (but should be near the top).
 - Add to your `package.json` `scripts`: `"dtslint": "dtslint types"`
 - `npm run dtslint`
 
+### Options
+
+- `--localTs`
+
+Use your locally installed version of TypeScript.
+
+```sh
+dtslint --localTs node_modules/typescript/lib types
+```
+- `--expectOnly`
+
+Disable all the lint rules and check for type correctness only.
+
+```sh
+dtslint --expectOnly types
+```
+
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ dtslint --localTs node_modules/typescript/lib types
 ```
 - `--expectOnly`
 
-Disable all the lint rules and check for type correctness only.
+Disable all the lint rules except the one that checks for type correctness.
 
 ```sh
 dtslint --expectOnly types


### PR DESCRIPTION
The CLI accepts these options (`localTs` and `expectOnly`) but they're not documented anywhere. I have to look through the issues to realize they exist.

`--localTs` - https://github.com/microsoft/dtslint/issues/231#issuecomment-515769378
`--expectOnly` - https://github.com/microsoft/dtslint/issues/208#issuecomment-467977621

I think it'd be very helpful if this information could be found on the readme as well.