### PR TITLE
Remove long series of empty lines in tool output

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,7 +13,6 @@ export async function installAll() {
         // manually instead typescript@next outside the loop
         if (v === TypeScriptVersion.all[TypeScriptVersion.all.length - 1]) { continue; }
         await install(v);
-        console.log("");
     }
     await installNext();
 }
@@ -33,6 +32,7 @@ async function install(version: TsVersion): Promise<void> {
         await fs.writeJson(path.join(dir, "package.json"), packageJson(version));
         await execAndThrowErrors("npm install --ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links", dir);
         console.log("Installed!");
+        console.log("");
     }
 }
 


### PR DESCRIPTION
Currently, if the TS version already cached our `npm t` output looks like this:
![image](https://user-images.githubusercontent.com/8336157/63505360-12df8b00-c4dc-11e9-995d-bce6a9a11bb7.png)
