### PR TITLE
Support $ExpectType with || separating multiple choices

### DIFF
--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -371,7 +371,7 @@ function getExpectTypeFailures(
                 ? checker.typeToString(type, /*enclosingDeclaration*/ undefined, ts.TypeFormatFlags.NoTruncation)
                 : "";
 
-            if (actual !== expected && !matchReadonlyArray(actual, expected)) {
+            if (!expected.split(/\s*\|\|\s*/).some(s => actual === s || matchReadonlyArray(actual, s))) {
                 unmetExpectations.push({ node, expected, actual });
             }
 


### PR DESCRIPTION
With this PR we allow `$ExpectType` to specify multiple choices separated by `||`. For example:

```ts
// $ExpectType Output || ReadonlyArray<string>
stdout.inspectSync({ isTTY: false }, (output) => output);
```

This change is needed in preparation for https://github.com/microsoft/TypeScript/pull/33050 which causes type aliases to be preserved in type print-back where they were previously expanded.