### PR TITLE
Fix regex typo for Minimum TypeScript Version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ function assertPathIsNotBanned(dirPath: string) {
 }
 
 function getTypeScriptVersionFromComment(text: string): AllTypeScriptVersion | undefined {
-    const match = text.match(/\/\/ (?:Minimum)? TypeScript Version: /);
+    const match = text.match(/\/\/ (?:Minimum )?TypeScript Version: /);
     if (!match) {
         return undefined;
     }


### PR DESCRIPTION
Sorry @sandersn 🙈 

Fixes a mistake in #265 

I couldn’t figure out how to test this with the existing test setup. I guess if it doesn’t get recognized as a TS Version line, it just gets treated as a normal comment and doesn’t error, so you can’t really test it as a lint rule itself.