### PR TITLE
Tslint updater

### DIFF
--- a/dt.json
+++ b/dt.json
@@ -8,6 +8,8 @@
 		"no-outside-dependencies": true,
 
 		"no-redundant-jsdoc": false,
-		"no-redundant-jsdoc-2": true
+		"no-redundant-jsdoc-2": true,
+
+		"npm-naming": [true, { "mode": "code" }]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,6 +18,12 @@
         "@types/node": "*"
       }
     },
+    "@types/json-stable-stringify": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz",
+      "integrity": "sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.12.tgz",
@@ -31,7 +37,7 @@
     },
     "@types/strip-json-comments": {
       "version": "0.0.28",
-      "resolved": "http://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.28.tgz",
       "integrity": "sha1-pEXYXWNhaXApTQeTJ1lwdPnKdwA=",
       "dev": true
     },
@@ -80,7 +86,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -562,6 +568,14 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -569,6 +583,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "lcid": {
       "version": "2.0.0",
@@ -714,7 +733,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -784,7 +803,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
@@ -814,7 +833,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -869,9 +888,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.0-dev.20200215",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200215.tgz",
-      "integrity": "sha512-B4VE2NldE3UMvxpCCz8hR2xByjLH4XJYdbKpMoxl4cpG2/yLGIfxgf4B854hx9ZgMc+7lWzO/+b90vYVoRi/7g=="
+      "version": "3.9.0-dev.20200219",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200219.tgz",
+      "integrity": "sha512-MuH6+UIDR3nHlR0RbmsCl+9XXogbYKbnY+luKgjtUOpJqKkJvyA5o4HRw18dTRFJntPz8ZJpjB/UEELBvJq4UQ=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "@types/fs-extra": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
@@ -20,14 +25,29 @@
       "dev": true
     },
     "@types/parsimmon": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
-      "integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.1.tgz",
+      "integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q=="
     },
     "@types/strip-json-comments": {
       "version": "0.0.28",
       "resolved": "http://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.28.tgz",
       "integrity": "sha1-pEXYXWNhaXApTQeTJ1lwdPnKdwA=",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
+      "integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
     "ansi-regex": {
@@ -125,26 +145,26 @@
       }
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -225,17 +245,169 @@
         "yargs": "^12.0.5"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
         "typescript": {
           "version": "3.7.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
           "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -275,11 +447,12 @@
       }
     },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "fs-extra": {
@@ -298,9 +471,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -311,9 +484,9 @@
       }
     },
     "glob": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -361,9 +534,9 @@
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -406,12 +579,11 @@
       }
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "map-age-cleaner": {
@@ -518,11 +690,11 @@
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-try": {
@@ -536,9 +708,9 @@
       "integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A=="
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -570,22 +742,22 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -616,25 +788,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -696,9 +869,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.0-dev.20200214",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200214.tgz",
-      "integrity": "sha512-ZzlRrmPxBamTC4rdohVXdu4X2iRyuKiM24BjzoTXv7kKExHUMhMqbaY8tWUXr6rxyZCiXk+/CkJptsFa37IVGg=="
+      "version": "3.9.0-dev.20200215",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200215.tgz",
+      "integrity": "sha512-B4VE2NldE3UMvxpCCz8hR2xByjLH4XJYdbKpMoxl4cpG2/yLGIfxgf4B854hx9ZgMc+7lWzO/+b90vYVoRi/7g=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -719,30 +892,48 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -758,28 +949,27 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^16.1.0"
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/yargs": "^15.0.3"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=10.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/yargs": "^15.0.3"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "fs-extra": "^6.0.1",
     "strip-json-comments": "^2.0.1",
     "tslint": "5.14.0",
-    "typescript": "next"
+    "typescript": "next",
+    "yargs": "^15.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.2",
     "@types/node": "12.0.x",
-    "@types/strip-json-comments": "^0.0.28"
+    "@types/strip-json-comments": "^0.0.28",
+    "@types/yargs": "^15.0.3"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "definitelytyped-header-parser": "3.8.2",
     "dts-critic": "^3.0.0",
     "fs-extra": "^6.0.1",
+    "json-stable-stringify": "^1.0.1",
     "strip-json-comments": "^2.0.1",
     "tslint": "5.14.0",
     "typescript": "next",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.2",
+    "@types/json-stable-stringify": "^1.0.32",
     "@types/node": "12.0.x",
     "@types/strip-json-comments": "^0.0.28",
     "@types/yargs": "^15.0.3"

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -50,7 +50,6 @@ export async function lint(
         // typesVersions should be handled in a separate lint
         if (!isExternalDependency(file, dirPath, lintProgram) &&
             (inTypesVersionDirectory || !isTypesVersionPath(fileName, dirPath))) {
-            console.log(fileName, JSON.stringify(config));
             linter.lint(fileName, text, config);
         }
     }
@@ -170,7 +169,6 @@ async function getLintConfig(
             range(minVersion, maxVersion).map(versionName => ({ versionName, path: typeScriptPath(versionName, tsLocal) }));
         const expectOptions: ExpectOptions = { tsconfigPath, versionsToTest };
         expectRule.ruleArguments = [expectOptions];
-        console.log("Expect args\n", JSON.stringify(expectOptions, undefined, 4));
     }
     return config;
 }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -50,6 +50,7 @@ export async function lint(
         // typesVersions should be handled in a separate lint
         if (!isExternalDependency(file, dirPath, lintProgram) &&
             (inTypesVersionDirectory || !isTypesVersionPath(fileName, dirPath))) {
+            console.log(fileName, JSON.stringify(config));
             linter.lint(fileName, text, config);
         }
     }
@@ -79,7 +80,7 @@ function testDependencies(
     return `Errors in typescript@${version} for external dependencies:\n${showDiags}`;
 }
 
-function isExternalDependency(file: TsType.SourceFile, dirPath: string, program: TsType.Program): boolean {
+export function isExternalDependency(file: TsType.SourceFile, dirPath: string, program: TsType.Program): boolean {
     return !startsWithDirectory(file.fileName, dirPath) || program.isSourceFileFromExternalLibrary(file);
 }
 
@@ -169,6 +170,7 @@ async function getLintConfig(
             range(minVersion, maxVersion).map(versionName => ({ versionName, path: typeScriptPath(versionName, tsLocal) }));
         const expectOptions: ExpectOptions = { tsconfigPath, versionsToTest };
         expectRule.ruleArguments = [expectOptions];
+        console.log("Expect args\n", JSON.stringify(expectOptions, undefined, 4));
     }
     return config;
 }

--- a/src/rules/npmNamingRule.ts
+++ b/src/rules/npmNamingRule.ts
@@ -6,7 +6,6 @@ import {
     ErrorKind,
     ExportErrorKind,
     Mode,
-    NameOnlyOptions,
     parseExportErrorKind,
     parseMode } from "dts-critic";
 import * as Lint from "tslint";
@@ -14,9 +13,16 @@ import * as ts from "typescript";
 
 import { failure, isMainFile } from "../util";
 
-type Options = CriticOptions & { singleLine?: boolean };
+type Options = {
+    mode: Mode.NameOnly,
+    singleLine?: boolean,
+} | {
+    mode: Mode.Code,
+    errors: Array<[ExportErrorKind, boolean]>,
+    singleLine?: boolean,
+};
 
-const defaultOptions: NameOnlyOptions = {
+const defaultOptions: Options = {
     mode: Mode.NameOnly,
 };
 
@@ -81,7 +87,7 @@ If \`mode\` is '${Mode.Code}', then option \`errors\` can be provided.
             true,
             [true, { mode: Mode.NameOnly }],
             [true, { mode: Mode.Code, errors: [[ErrorKind.NeedsExportEquals, true], [ErrorKind.NoDefaultExport, false]] }],
-        ],
+        ] as Array<true | [true, Options]>,
         type: "functionality",
         typescriptOnly: true,
     };
@@ -117,14 +123,14 @@ function parseOptions(args: unknown[]): Options {
             return { mode, singleLine };
         case Mode.Code:
             if (!arg.errors || !Array.isArray(arg.errors)) {
-                return { mode, errors: new Map(), singleLine };
+                return { mode, errors: [], singleLine };
             }
             return { mode, errors: parseEnabledErrors(arg.errors), singleLine };
     }
 }
 
-function parseEnabledErrors(errors: unknown[]): Map<ExportErrorKind, boolean> {
-    const enabledChecks = new Map<ExportErrorKind, boolean>();
+function parseEnabledErrors(errors: unknown[]): Array<[ExportErrorKind, boolean]> {
+    const enabledChecks: Array<[ExportErrorKind, boolean]> = [];
     for (const tuple of errors) {
         if (Array.isArray(tuple)
             && tuple.length === 2
@@ -132,11 +138,21 @@ function parseEnabledErrors(errors: unknown[]): Map<ExportErrorKind, boolean> {
             && typeof tuple[1] === "boolean") {
             const error = parseExportErrorKind(tuple[0]);
             if (error) {
-                enabledChecks.set(error, tuple[1]);
+                enabledChecks.push([error, tuple[1]]);
             }
         }
     }
     return enabledChecks;
+}
+
+function toCriticOptions(options: Options): CriticOptions {
+    switch (options.mode) {
+        case Mode.NameOnly:
+            return options;
+        case Mode.Code:
+            const errors = new Map(options.errors);
+            return { ...options, errors };
+    }
 }
 
 function tslintDisableOption(error: ErrorKind): string {
@@ -180,7 +196,7 @@ function walk(ctx: Lint.WalkContext<Options>): void {
     };
     if (isMainFile(sourceFile.fileName, /*allowNested*/ false)) {
         try {
-            const errors = critic(sourceFile.fileName, /* sourcePath */ undefined, ctx.options);
+            const errors = critic(sourceFile.fileName, /* sourcePath */ undefined, toCriticOptions(ctx.options));
             for (const error of errors) {
                 switch (error.kind) {
                     case ErrorKind.NoMatchingNpmPackage:
@@ -218,34 +234,32 @@ function walk(ctx: Lint.WalkContext<Options>): void {
  */
 export function disabler(failures: Lint.IRuleFailureJson[]): false | [true, Options] {
     const disabledErrors = new Set<ExportErrorKind>();
-    for (const failure of failures) {
-        if (failure.ruleName != "npm-naming") {
-            throw new Error(`Expected failures of rule "npm-naming", found failures of rule ${failure.ruleName}.`);
+    for (const ruleFailure of failures) {
+        if (ruleFailure.ruleName !== "npm-naming") {
+            throw new Error(`Expected failures of rule "npm-naming", found failures of rule ${ruleFailure.ruleName}.`);
         }
-        const message = failure.failure;
+        const message = ruleFailure.failure;
         // Name errors.
         if (message.includes("must have a matching npm package")
-            || message.includes("must have a version that exists on npm")
+            || message.includes("must match a version that exists on npm")
             || message.includes("conflicts with the existing npm package")) {
             return false;
         }
         // Code errors.
         if (message.includes("declaration should use 'export =' syntax")) {
             disabledErrors.add(ErrorKind.NeedsExportEquals);
-        }
-        else if (message.includes("declaration specifies 'export default' but the JavaScript source \
+        } else if (message.includes("declaration specifies 'export default' but the JavaScript source \
             does not mention 'default' anywhere")) {
             disabledErrors.add(ErrorKind.NoDefaultExport);
-        }
-        else {
+        } else {
             return [true, { mode: Mode.NameOnly }];
         }
     }
-    
+
     if ((defaultErrors as ExportErrorKind[]).every(error => disabledErrors.has(error))) {
         return [true, { mode: Mode.NameOnly }];
     }
-    const errors = new Map();
-    disabledErrors.forEach((error) => errors.set(error, false));
+    const errors: Array<[ExportErrorKind, boolean]> = [];
+    disabledErrors.forEach(error => errors.push([error, false]));
     return [true, { mode: Mode.Code, errors }];
 }

--- a/src/updateConfig.ts
+++ b/src/updateConfig.ts
@@ -1,3 +1,12 @@
+// This is a stand-alone script that updates TSLint configurations for DefinitelyTyped packages.
+// It runs all rules specified in `dt.json`, and updates the existing configuration for a package
+// by adding rule exemptions only for the rules that caused a lint failure.
+// For example, if a configuration specifies `"no-trailing-whitespace": false` and this rule
+// no longer produces an error, then it will not be disabled in the new configuration.
+// If you update or create a rule and now it causes new failures in DT, you can update the `dt.json`
+// configuration with your rule, then register a disabler function for your rule
+// (check `ruleDisablers` below), then run this script with your rule as argument.
+
 import cp = require("child_process");
 import fs = require("fs");
 import stringify = require("json-stable-stringify");

--- a/src/updateConfig.ts
+++ b/src/updateConfig.ts
@@ -1,3 +1,4 @@
+import cp = require("child_process");
 import fs = require("fs");
 import stringify = require("json-stable-stringify");
 import path = require("path");
@@ -73,6 +74,7 @@ function updateAll(dtPath: string, config: Config.IConfigurationFile): void {
 }
 
 function updatePackage(pkgPath: string, baseConfig: Config.IConfigurationFile): void {
+    installDependencies(pkgPath);
     const packages = walkPackageDir(pkgPath);
 
     const linterOpts: ILinterOptions = {
@@ -86,6 +88,17 @@ function updatePackage(pkgPath: string, baseConfig: Config.IConfigurationFile): 
             const newConfig = mergeConfigRules(pkg.config(), disabledRules, baseConfig);
             pkg.updateConfig(newConfig);
         }
+    }
+}
+
+function installDependencies(pkgPath: string): void {
+    if (fs.existsSync(path.join(pkgPath, "package.json"))) {
+        cp.execSync(
+            "npm install --ignore-scripts --no-shrinkwrap --no-package-lock --no-bin-links",
+            {
+                encoding: "utf8",
+                cwd: pkgPath,
+            });
     }
 }
 

--- a/src/updateConfig.ts
+++ b/src/updateConfig.ts
@@ -1,0 +1,198 @@
+import path from "path";
+import fs from "fs";
+import { isExternalDependency } from "./lint";
+import { Configuration as Config, ILinterOptions, Linter, RuleFailure, IRuleFailureJson, LintResult } from "tslint";
+import { disabler as npmNamingDisabler } from "./rules/npmNamingRule";
+import * as ts from "typescript";
+import yargs = require("yargs");
+
+function main() {
+    // TODO: write about our assumptions of config file (dt.json).
+    const args = yargs
+        .option("package", {
+            describe: "Path of DT package.",
+            type: "string",
+            conflicts: "dt",
+        })
+        .option("dt", {
+            describe: "Path of local DefinitelyTyped repository.",
+            type: "string",
+            conflicts: "package",
+        })
+        .check(arg => {
+            if (!arg.package && !arg.dt) {
+                throw new Error("You must provide either argument 'package' or 'dt'.");
+            }
+            return true;
+        }).argv;
+    
+    if (args.package) {
+        updatePackage(args.package, dtConfig());
+    } else if (args.dt) {
+        updateAll(args.dt);
+    }
+}
+
+function dtConfig(): Config.IConfigurationFile {
+    const config = Config.findConfiguration(dtConfigPath).results;
+    if (!config) {
+        throw new Error(`Could not load config at ${dtConfigPath}.`);
+    }
+    return config;
+}
+
+function updateAll(dtPath: string): void {
+    const packages = fs.readdirSync(path.join(dtPath, "types"));
+    for (const pkg of packages) {
+        updatePackage(path.join(dtPath, "types", pkg), dtConfig());
+    }
+}
+
+function updatePackage(pkgPath: string, baseConfig: Config.IConfigurationFile): void {
+    const packages = walkPackageDir(pkgPath);
+
+    const linterOpts: ILinterOptions = {
+        fix: false,
+    };
+
+    // console.log(packages);
+    for (const pkg of packages) {
+        const results = pkg.lint(linterOpts, baseConfig);
+        if (results.failures.length > 0) {
+            const newRulesConfig = disableRules(results.failures);
+            const oldConfig: Config.RawConfigFile = pkg.config();
+            const newConfig: Config.RawConfigFile = { ...oldConfig, rules: newRulesConfig };
+            pkg.updateConfig(newConfig);
+        }
+    }
+}
+
+/** Represents a package from the linter's perspective. */
+// TODO: write more about this.
+class LintPackage {
+    private rootDir: string;
+    private files: ts.SourceFile[];
+    private program: ts.Program;
+
+    constructor(rootDir: string) {
+        this.rootDir = rootDir;
+        this.files = [];
+        this.program = Linter.createProgram(path.join(this.rootDir, "tsconfig.json"));
+    }
+
+    config(): Config.RawConfigFile {
+        return Config.readConfigurationFile(path.join(this.rootDir, "tslint.json"));
+    }
+
+    addFile(filePath: string): void {
+        const file = this.program.getSourceFile(filePath);
+        if (file) {
+            this.files.push(file);
+        }
+    }
+
+    lint(opts: ILinterOptions, config: Config.IConfigurationFile): LintResult {
+        const linter = new Linter(opts, this.program);
+        for (const file of this.files) {
+            if (ignoreFile(file, this.rootDir, this.program)) {
+                continue;
+            }
+            console.log(`Linting file ${file.fileName}.
+Root: ${this.rootDir}.`);
+            linter.lint(file.fileName, file.text, config);
+        }
+        return linter.getResult();
+    }
+
+    updateConfig(config: Config.RawConfigFile): void {
+        fs.writeFileSync(
+            path.join(this.rootDir, "tslint.json"),
+            JSON.stringify(config, /* replacer */ undefined, /* space */ 4),
+            { encoding: "utf8", flag: "w" });
+    }
+}
+
+function ignoreFile(file: ts.SourceFile, dirPath: string, program: ts.Program): boolean {
+    return program.isSourceFileDefaultLibrary(file) || isExternalDependency(file, path.resolve(dirPath), program);
+}
+
+function walkPackageDir(rootDir: string): LintPackage[] {
+    const packages: LintPackage[] = [];
+
+    function walk(curPackage: LintPackage, dir: string): void {
+        for (const ent of fs.readdirSync(dir, { encoding: "utf8", withFileTypes: true })) {
+            const entPath = path.join(dir, ent.name);
+            if (ent.isFile()) {
+                curPackage.addFile(entPath);
+            }
+            else if (ent.isDirectory()) {
+                if (isVersionDir(ent.name)) {
+                    const newPackage = new LintPackage(entPath);
+                    packages.push(newPackage)
+                    walk(newPackage, entPath);
+                } else {
+                    walk(curPackage, entPath);
+                }
+            }
+        }
+    }
+
+    const lintPackage = new LintPackage(rootDir);
+    packages.push(lintPackage);
+    walk(lintPackage, rootDir);
+    return packages;
+}
+
+/** Returns true if directory name matches a TypeScript or package version directory.
+ *  Examples: `ts3.5`, `v11`, v0.6
+*/
+function isVersionDir(dirName: string): boolean {
+    return /^ts\d+\.\d$/.test(dirName) || /^v\d+(\.\d+)?$/.test(dirName);
+}
+
+type RuleOptions = boolean | unknown[];
+type RuleDisabler = (failures: IRuleFailureJson[]) => RuleOptions;
+const defaultDisabler: RuleDisabler = (_) => {
+    return false;
+}
+const ruleDisablers: Map<string, RuleDisabler> = new Map([
+    ["npm-naming", npmNamingDisabler],
+]);
+
+function disableRules(failures: RuleFailure[]): Config.RawRulesConfig {
+    const ruleToFailures: Map<string, IRuleFailureJson[]> = new Map();
+    for (const failure of failures) {
+        const failureJson = failure.toJson();
+        console.log(JSON.stringify(failureJson));
+        if (ruleToFailures.has(failureJson.ruleName)) {
+            ruleToFailures.get(failureJson.ruleName)!.push(failureJson);
+        } else {
+            ruleToFailures.set(failureJson.ruleName, [failureJson]);
+        }
+    }
+
+    const newRulesConfig: Config.RawRulesConfig = {};
+    ruleToFailures.forEach((failures, rule) => {
+        const disabler = ruleDisablers.get(rule) || defaultDisabler;
+        const opts = disabler(failures);
+        newRulesConfig[rule] = opts;
+    });
+
+    return newRulesConfig;
+}
+
+const dtConfigPath = "dt.json";
+// const baseDtTslintConfig: Config.RawConfigFile = {
+//     extends: `dtslint/${dtConfigPath}`,
+// };
+
+// function readConfig(pkgPath: string): Config.RawConfigFile {
+//     if (fs.existsSync(path.join(pkgPath, "tslint.json"))) {
+//         return Config.readConfigurationFile(path.join(pkgPath, "tslint.json"));
+//     }
+//     return baseDtTslintConfig;
+// }
+
+if (!module.parent) {
+    main();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 		"noImplicitThis": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"strictNullChecks": true,
+		"strictNullChecks": true
 	},
 	"include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,6 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"strictNullChecks": true,
-		// TODO: remove,
-		"esModuleInterop": true,
 	},
 	"include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
 		"noImplicitThis": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		// TODO: remove,
+		"esModuleInterop": true,
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
This PR creates a script that runs TSLint for DT packages, taking as configuration `dt.json` and ignoring the existing `tslint.json` for the package. The output is a new `tslint.json` for the packages, that only adds exemptions for rules that actually produced lint failures.