### PR TITLE
feat: Disallow `"strict": false`

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -82,6 +82,7 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
                 case "lib":
                 case "noImplicitAny":
                 case "noImplicitThis":
+                case "strict":
                 case "strictNullChecks":
                 case "strictFunctionTypes":
                 case "esModuleInterop":
@@ -109,7 +110,17 @@ export async function checkTsconfig(dirPath: string, dt: DefinitelyTypedInfo | u
         throw new Error('Must specify "lib", usually to `"lib": ["es6"]` or `"lib": ["es6", "dom"]`.');
     }
 
-    if (!("strict" in options)) {
+    if ("strict" in options) {
+        if (options.strict !== true) {
+            throw new Error('When "strict" is present, it must be set to `true`.');
+        }
+
+        for (const key of ["noImplicitAny", "noImplicitThis", "strictNullChecks", "strictFunctionTypes"]) {
+            if (key in options) {
+                throw new TypeError(`Expected "${key}" to not be set when "strict" is \`true\`.`);
+            }
+        }
+    } else {
         for (const key of ["noImplicitAny", "noImplicitThis", "strictNullChecks", "strictFunctionTypes"]) {
             if (!(key in options)) {
                 throw new Error(`Expected \`"${key}": true\` or \`"${key}": false\`.`);


### PR DESCRIPTION
This disallows setting `"strict": false` in **DefinitelyTyped** packages, as there’s no package that has `strict` set to `false`, only 3 that have it set to `true`.

I’m opening this as a new PR, because <https://github.com/microsoft/dtslint/pull/275> depends on all **DefinitelyTyped** packages having `"noImplicitAny": true`, which will require fixing the remaining 49 packages that won’t yet be fixed by <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42682>.

---

I’ve also disallowed overriding `"strict": true` with `"noImplicitAny"`, `"noImplicitThis"`, `"strictNullChecks"` or `"strictFunctionTypes"`, as no **DefinitelyTyped** package does this either.