### PR TITLE
Use TypeScriptVersion.latest instead of "next"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -37,7 +37,7 @@
     },
     "@types/strip-json-comments": {
       "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.28.tgz",
       "integrity": "sha1-pEXYXWNhaXApTQeTJ1lwdPnKdwA=",
       "dev": true
     },
@@ -91,7 +91,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -612,7 +612,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -682,7 +682,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ async function runTests(
     }
 
     if (onlyTestTsNext || tsLocal) {
-        const tsVersion = tsLocal ? "local" : "next";
+        const tsVersion = tsLocal ? "local" : TypeScriptVersion.latest;
         if (typesVersions.length === 0) {
             await testTypesVersion(dirPath, tsVersion, tsVersion, isOlderVersion, dt, indexText, expectOnly, tsLocal);
         } else {
@@ -177,7 +177,7 @@ async function runTests(
         }
 
         function getTsVersion(i: number): TsVersion {
-            return i === typesVersions.length ? "next" : assertDefined(TypeScriptVersion.previous(typesVersions[i]));
+            return i === typesVersions.length ? TypeScriptVersion.latest : assertDefined(TypeScriptVersion.previous(typesVersions[i]));
         }
     }
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -49,6 +49,9 @@ export function typeScriptPath(version: TsVersion, tsLocal: string | undefined):
 
 function installDir(version: TsVersion): string {
     assert(version !== "local");
+    if (version === "next") {
+        version = TypeScriptVersion.latest;
+    }
     return path.join(installsDir, version);
 }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,7 +21,7 @@ export async function installNext() {
     await install("next");
 }
 
-async function install(version: TsVersion): Promise<void> {
+async function install(version: TsVersion | "next"): Promise<void> {
     if (version === "local") {
         return;
     }
@@ -47,7 +47,7 @@ export function typeScriptPath(version: TsVersion, tsLocal: string | undefined):
     return path.join(installDir(version), "node_modules", "typescript");
 }
 
-function installDir(version: TsVersion): string {
+function installDir(version: TsVersion | "next"): string {
     assert(version !== "local");
     if (version === "next") {
         version = TypeScriptVersion.latest;
@@ -72,7 +72,7 @@ async function execAndThrowErrors(cmd: string, cwd?: string): Promise<void> {
     });
 }
 
-function packageJson(version: TsVersion): {} {
+function packageJson(version: TsVersion | "next"): {} {
     return {
         description: `Installs typescript@${version}`,
         repository: "N/A",

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -66,9 +66,6 @@ function testDependencies(
 ): string | undefined {
     const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
     assert(version !== "local" || tsLocal);
-    if (version === TypeScriptVersion.latest) {
-        version = "next";
-    }
     const ts: typeof TsType = require(typeScriptPath(version, tsLocal));
     const program = getProgram(tsconfigPath, ts, version, lintProgram);
     const diagnostics = ts.getPreEmitDiagnostics(program).filter(d => !d.file || isExternalDependency(d.file, dirPath, program));

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -174,30 +174,19 @@ async function getLintConfig(
 }
 
 function range(minVersion: TsVersion, maxVersion: TsVersion): ReadonlyArray<TsVersion> {
-    if (minVersion === "next") {
-        assert(maxVersion === "next");
-        return ["next"];
-    }
     if (minVersion === "local") {
         assert(maxVersion === "local");
         return ["local"];
     }
+    assert(maxVersion !== "local");
 
     // The last item of TypeScriptVersion is the unreleased version of Typescript,
     // which is called 'next' on npm, so replace it with 'next'.
-    if (minVersion === TypeScriptVersion.latest) {
-        minVersion = "next";
-    }
-    if (maxVersion === TypeScriptVersion.latest) {
-        maxVersion = "next";
-    }
-    const allReleased: TsVersion[] = [...TypeScriptVersion.supported];
-    allReleased[allReleased.length - 1] = "next";
-    const minIdx = allReleased.indexOf(minVersion);
+    const minIdx = TypeScriptVersion.supported.indexOf(minVersion);
     assert(minIdx >= 0);
-    const maxIdx = allReleased.indexOf(maxVersion);
+    const maxIdx = TypeScriptVersion.supported.indexOf(maxVersion as TypeScriptVersion);
     assert(maxIdx >= minIdx);
-    return allReleased.slice(minIdx, maxIdx + 1);
+    return TypeScriptVersion.supported.slice(minIdx, maxIdx + 1);
 }
 
-export type TsVersion = TypeScriptVersion | "next" | "local";
+export type TsVersion = TypeScriptVersion | "local";

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -66,6 +66,9 @@ function testDependencies(
 ): string | undefined {
     const tsconfigPath = joinPaths(dirPath, "tsconfig.json");
     assert(version !== "local" || tsLocal);
+    if (version === TypeScriptVersion.latest) {
+        version = "next";
+    }
     const ts: typeof TsType = require(typeScriptPath(version, tsLocal));
     const program = getProgram(tsconfigPath, ts, version, lintProgram);
     const diagnostics = ts.getPreEmitDiagnostics(program).filter(d => !d.file || isExternalDependency(d.file, dirPath, program));
@@ -185,6 +188,12 @@ function range(minVersion: TsVersion, maxVersion: TsVersion): ReadonlyArray<TsVe
 
     // The last item of TypeScriptVersion is the unreleased version of Typescript,
     // which is called 'next' on npm, so replace it with 'next'.
+    if (minVersion === TypeScriptVersion.latest) {
+        minVersion = "next";
+    }
+    if (maxVersion === TypeScriptVersion.latest) {
+        maxVersion = "next";
+    }
     const allReleased: TsVersion[] = [...TypeScriptVersion.supported];
     allReleased[allReleased.length - 1] = "next";
     const minIdx = allReleased.indexOf(minVersion);

--- a/src/util.ts
+++ b/src/util.ts
@@ -75,7 +75,7 @@ export function assertDefined<T>(a: T | undefined): T {
     return a;
 }
 
-export async function mapDefinedAsync<T, U>(arr: Iterable<T>, mapper: (t: T) => Promise<U | undefined>): Promise<U[]> {
+export async function mapDefinedAsync<T, U>(arr: Iterable<T>, mapper: (t: T) => Promise<U | undefined>): Promise<(awaited U)[]> {
     const out = [];
     for (const a of arr) {
         const res = await mapper(a);


### PR DESCRIPTION
Except when installing from npm. definitelytyped-header-parser has it right, but dtslint previously went through hoops to add "next" so that it could install `typescript@next` from npm. This PR reduces the scope of that addition to just `installer.ts`. Everywhere else just treats the next version as a normal version number.