### PR TITLE
Support parallel minor versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -758,9 +758,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.0-dev.20200323",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200323.tgz",
-      "integrity": "sha512-PyI3tW2rJ/Q1llOj3dm2wiQb45vIyWct7I/rnGrllSSJ7+O0X5iU9iw0LaOvd98vraooeyIJ1fBkrtyntxv7Kw=="
+      "version": "3.9.0-dev.20200327",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200327.tgz",
+      "integrity": "sha512-/TWD/zPvhAcN2Toqx2NBQ+oDVGVj4iqupjWcUAwL45TfcODeHpzszneABR1b/EjHbtUObtLH40vy5Z6rdVvKzg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ async function testTypesVersion(
 
 function assertPathIsInDefinitelyTyped(dirPath: string): void {
     const parent = dirname(dirPath);
-    const types = /^v\d+$/.test(basename(dirPath)) ? dirname(parent) : parent;
+    const types = /^v\d+(\.\d+)?$/.test(basename(dirPath)) ? dirname(parent) : parent;
     // TODO: It's not clear whether this assertion makes sense, and it's broken on Azure Pipelines
     // Re-enable it later if it makes sense.
     // const dt = dirname(types);

--- a/src/util.ts
+++ b/src/util.ts
@@ -76,8 +76,7 @@ export function assertDefined<T>(a: T | undefined): T {
 }
 
 export async function mapDefinedAsync<T, U>(
-    arr: Iterable<T>, mapper: (t: T) => Promise<U | undefined>):
-Promise<Array<awaited U>> {
+    arr: Iterable<T>, mapper: (t: T) => Promise<U | undefined>): Promise<U[]> {
     const out = [];
     for (const a of arr) {
         const res = await mapper(a);


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/types-publisher/pull/723.

This was causing [CI on DT](https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/667674430#L544) to fail for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43179.

I couldn't figure out how to write a test to exercise this code-path. If it’s easy to point out, I’d gladly add test coverage.