### PR TITLE
Adds a rough approximation of deprecated support

### DIFF
--- a/src/rules/noRedundantJsdoc2Rule.ts
+++ b/src/rules/noRedundantJsdoc2Rule.ts
@@ -59,6 +59,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
     });
 
     function checkTag(tag: ts.JSDocTag): void {
+        // @ts-ignore (until support for 4.0 is added)
+        const JSDocDeprecatedTag = ts.SyntaxKind["JSDocDeprecatedTag"] || 0
         switch (tag.kind) {
             case ts.SyntaxKind.JSDocTag: {
                 const { tagName } = tag;
@@ -85,6 +87,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
             case ts.SyntaxKind.JSDocCallbackTag:
             case ts.SyntaxKind.JSDocThisTag:
             case ts.SyntaxKind.JSDocEnumTag:
+            case JSDocDeprecatedTag:
+
                 // Always redundant
                 ctx.addFailureAtNode(
                     tag.tagName,


### PR DESCRIPTION
In DT, if a .d.ts includes `@deprecated` in their types then as of 4.0 we pass back a `JSDocDeprecatedTag` but that hasn't been recognized yet in dtslint.

Kinda fixes https://github.com/microsoft/dtslint/issues/299 but with a hack

In lieu of https://github.com/microsoft/dtslint/pull/285 and eventually a subsequent PR to 4.0 - I _think_ this would fix CI on DT to detect the new JSDoc tag.

Should probably unblock https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46238