### PR TITLE
Allow references to typesVersions parent

### DIFF
--- a/src/rules/noBadReferenceRule.ts
+++ b/src/rules/noBadReferenceRule.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
@@ -29,7 +30,8 @@ function walk(ctx: Lint.WalkContext<void>): void {
     const { sourceFile } = ctx;
     for (const ref of sourceFile.referencedFiles) {
         if (sourceFile.isDeclarationFile) {
-            if (ref.fileName.startsWith("..")) {
+            const dirPath = path.dirname(sourceFile.fileName);
+            if (path.normalize(ref.fileName).startsWith(/^ts\d+\.\d$/.test(path.basename(dirPath)) ? "../.." : "..")) {
                 ctx.addFailure(ref.pos, ref.end, Rule.FAILURE_STRING);
             }
         } else {

--- a/test/no-bad-reference/ts2.0/index.d.ts.lint
+++ b/test/no-bad-reference/ts2.0/index.d.ts.lint
@@ -1,0 +1,1 @@
+/// <reference path="../ts1.0/index.d.ts" />


### PR DESCRIPTION
Like [@definitelytyped/definitions-parser](https://github.com/microsoft/DefinitelyTyped-tools/blob/c93087b4c92940de8945cd59ee6ee7fa97c43ffa/packages/definitions-parser/src/lib/module-info.ts#L251-L259), allow e.g. [`/// <reference path="../ts3.4/base.d.ts" />`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b189e0562e6db11a2107bda5264e86681880dbfa/types/node/ts3.6/base.d.ts#L16-L17).