### PR TITLE
Copy advice from the DT common mistakes

### DIFF
--- a/docs/no-unnecessary-generics.md
+++ b/docs/no-unnecessary-generics.md
@@ -46,6 +46,13 @@ function clear(array: any[]): void;
 
 ---
 
+`getMeAT<T>(): T`:
+If a type parameter does not appear in the types of any parameters, you don't really have a generic function, you just have a disguised type assertion.
+Prefer to use a real type assertion, e.g. `getMeAT() as number`.
+Example where a type parameter is acceptable: `function id<T>(value: T): T;`.
+Example where it is not acceptable: `function parseJson<T>(json: string): T;`.
+Exception: `new Map<string, number>()` is OK.
+
 **Bad**:
 
 ```ts


### PR DESCRIPTION
Copy [this advice](https://github.com/DefinitelyTyped/DefinitelyTyped#user-content-common-mistakes:~:text=If%20a%20type%20parameter%20does%20not,just%20have%20a%20disguised%20type%20assertion) from the DefinitelyTyped common mistakes, since it explains not only what this rule matches, but why, and this doc is where authors are sent when it fails.