### PR TITLE
Improve handling of // in strings

### DIFF
--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -241,7 +241,7 @@ function parseAssertions(sourceFile: SourceFile): Assertions {
     const duplicates: number[] = [];
 
     const { text } = sourceFile;
-    const commentRegexp = /\/\/(.*)/g;
+    const commentRegexp = /\/\/ \$(.*)/g;
     const lineStarts = sourceFile.getLineStarts();
     let curLine = 0;
 
@@ -253,7 +253,7 @@ function parseAssertions(sourceFile: SourceFile): Assertions {
         }
         // Match on the contents of that comment so we do nothing in a commented-out assertion,
         // i.e. `// foo; // $ExpectType number`
-        const match = /^ \$Expect((Type (.*))|Error)$/.exec(commentMatch[1]);
+        const match = /^Expect((Type (.*))|Error)$/.exec(commentMatch[1]);
         if (match === null) {
             continue;
         }


### PR DESCRIPTION
...by searching for `// $` instead.  This still doesn't consider string boundaries, but is much less likely to occur accidentally (in a URL, for example).