### PR TITLE
Make dtslint work for directories with minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dtslint",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Runs tests on TypeScript definition files",
   "files": [
     "bin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ async function runTests(
     expectOnly: boolean,
     tsLocal: string | undefined,
 ): Promise<void> {
-    const isOlderVersion = /^v\d+$/.test(basename(dirPath));
+    const isOlderVersion = /^v(\d+)(\.(\d+))?$/.test(basename(dirPath));
 
     const indexText = await readFile(joinPaths(dirPath, "index.d.ts"), "utf-8");
     // If this *is* on DefinitelyTyped, types-publisher will fail if it can't parse the header.

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,9 +98,9 @@ export function isMainFile(fileName: string, allowNested: boolean) {
     }
 
     let parent = dirname(fileName);
-    // May be a directory for an older version, e.g. `v0`.
+    // May be a directory for an older version, e.g. `v0` or `v0.1`.
     // Note a types redirect `foo/ts3.1` should not have its own header.
-    if (allowNested && /^v\d+$/.test(basename(parent))) {
+    if (allowNested && /^v\d+(\.\d+)?$/.test(basename(parent))) {
         parent = dirname(parent);
     }
 

--- a/test/dt-header/correct/types/foo/v0.1/index.d.ts.lint
+++ b/test/dt-header/correct/types/foo/v0.1/index.d.ts.lint
@@ -1,0 +1,5 @@
+// Type definitions for dt-header 0.1
+// Project: https://github.com/bobby-headers/dt-header
+// Definitions by: Jane Doe <https://github.com/janedoe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1

--- a/test/dt-header/correct/types/foo/v0/index.d.ts.lint
+++ b/test/dt-header/correct/types/foo/v0/index.d.ts.lint
@@ -1,0 +1,5 @@
+// Type definitions for dt-header 0.0
+// Project: https://github.com/bobby-headers/dt-header
+// Definitions by: Jane Doe <https://github.com/janedoe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Minimum TypeScript Version: 3.1

--- a/test/dt-header/wrong/types/foo/ts3.1/index.d.ts.lint
+++ b/test/dt-header/wrong/types/foo/ts3.1/index.d.ts.lint
@@ -1,0 +1,2 @@
+// Type definitions for dt-header v1.0
+~~~~~~~~~~~~~~~~~~~~~~~ [Header should only be in `index.d.ts` of the root. See: https://github.com/Microsoft/dtslint/blob/master/docs/dt-header.md]


### PR DESCRIPTION
Fixes #333 

This PR will allow the dtslinter to work with directories that contain minor version numbers. For example if I define a v0.63 directory, these changes will allow dtslinter to correctly lint that directory.

Changed some regex's in the index and util files to account for minor versions. Added some tests to ensure that the behavior is working as intended.

Bumping package.json version so that these changes can be used by DT.

Ran tests and the dt-header tests run as expected.