### PR TITLE
Disable no-redundant-undefined rule

### DIFF
--- a/dtslint.json
+++ b/dtslint.json
@@ -10,7 +10,6 @@
         "no-dead-reference": true,
         "no-import-default-of-export-equals": true,
         "no-padding": true,
-        "no-redundant-undefined": true,
         "no-relative-import-in-test": true,
         "strict-export-declare-modifiers": true,
         "no-any-union": true,


### PR DESCRIPTION
It is going to turn into redundant-undefined soon, but in the meantime I need to turn off the rule so that I can switch DT from complying with no-redundant-undefined to complying with redundant-undefined.