### PR TITLE
Allow pre-1.0 /v* subdirectories.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ async function runTests(
     expectOnly: boolean,
     tsLocal: string | undefined,
 ): Promise<void> {
-    const isOlderVersion = /^v\d+$/.test(basename(dirPath));
+    const isOlderVersion = /^v(0\.)?\d+$/.test(basename(dirPath));
 
     const indexText = await readFile(joinPaths(dirPath, "index.d.ts"), "utf-8");
     // If this *is* on DefinitelyTyped, types-publisher will fail if it can't parse the header.

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,7 +100,7 @@ export function isMainFile(fileName: string, allowNested: boolean) {
     let parent = dirname(fileName);
     // May be a directory for an older version, e.g. `v0`.
     // Note a types redirect `foo/ts3.1` should not have its own header.
-    if (allowNested && /^v\d+$/.test(basename(parent))) {
+    if (allowNested && /^v(0\.)?\d+$/.test(basename(parent))) {
         parent = dirname(parent);
     }
 

--- a/test/dt-header/correct/types/foo/v0.75/index.d.ts.lint
+++ b/test/dt-header/correct/types/foo/v0.75/index.d.ts.lint
@@ -1,4 +1,4 @@
-// Type definitions for dt-header 2.0
+// Type definitions for dt-header 0.75
 // Project: https://github.com/bobby-headers/dt-header
 // Definitions by: Jane Doe <https://github.com/janedoe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/test/dt-header/correct/types/foo/v1/index.d.ts.lint
+++ b/test/dt-header/correct/types/foo/v1/index.d.ts.lint
@@ -1,4 +1,4 @@
-// Type definitions for dt-header 2.0
+// Type definitions for dt-header 1.0
 // Project: https://github.com/bobby-headers/dt-header
 // Definitions by: Jane Doe <https://github.com/janedoe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Does not allow arbitrary minor versions, only 0.*
Matches microsoft/types-publisher#723

Fixes #333