### PR TITLE
fix(no-single-declare-module): allow single wildcard module declaration

### DIFF
--- a/src/rules/noSingleDeclareModuleRule.ts
+++ b/src/rules/noSingleDeclareModuleRule.ts
@@ -34,6 +34,11 @@ function walk(ctx: Lint.WalkContext<void>): void {
     let moduleDecl: ts.ModuleDeclaration | undefined;
     for (const statement of sourceFile.statements) {
         if (ts.isModuleDeclaration(statement) && ts.isStringLiteral(statement.name)) {
+            if (statement.name.text.indexOf('*') !== -1) {
+                // Ignore wildcard module declarations
+                return;
+            }
+
             if (moduleDecl === undefined) {
                 moduleDecl = statement;
             } else {

--- a/test/no-single-declare-module/wildcard.d.ts.lint
+++ b/test/no-single-declare-module/wildcard.d.ts.lint
@@ -1,0 +1,1 @@
+declare module "*.svg" {}


### PR DESCRIPTION
Hello, I'm having trouble publishing a new DefinitelyTyped module (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55011) because a linting rule unintentionally forbids single [wildcard module declarations](https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations).

Here is a fix (with tests) that solves my issue.

Have a nice day!

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55011/checks?check_run_id=3288906960#step:6:94