### PR TITLE
Remove 'external module' wording from rules

### DIFF
--- a/src/rules/noDeclareCurrentPackageRule.ts
+++ b/src/rules/noDeclareCurrentPackageRule.ts
@@ -6,7 +6,7 @@ import { failure, getCommonDirectoryName } from "../util";
 export class Rule extends Lint.Rules.TypedRule {
     static metadata: Lint.IRuleMetadata = {
         ruleName: "no-declare-current-package",
-        description: "Don't use an ambient module declaration of the current package; use an external module.",
+        description: "Don't use an ambient module declaration of the current package; use a normal module.",
         optionsDescription: "Not configurable.",
         options: null,
         type: "functionality",

--- a/src/rules/noSingleDeclareModuleRule.ts
+++ b/src/rules/noSingleDeclareModuleRule.ts
@@ -6,7 +6,7 @@ import { failure } from "../util";
 export class Rule extends Lint.Rules.AbstractRule {
     static metadata: Lint.IRuleMetadata = {
         ruleName: "no-single-declare-module",
-        description: "Don't use an ambient module declaration if you can use an external module file.",
+        description: "Don't use an ambient module declaration if there's just one -- write it as a normal module.",
         rationale: "Cuts down on nesting",
         optionsDescription: "Not configurable.",
         options: null,
@@ -16,7 +16,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 
     static FAILURE_STRING = failure(
         Rule.metadata.ruleName,
-        "File has only 1 module declaration — write it as an external module.");
+        "File has only 1 ambient module declaration. Move the contents outside the ambient module block, rename the file to match the ambient module name, and remove the block.");
 
     apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithFunction(sourceFile, walk);

--- a/test/no-single-declare-module/wrong.d.ts.lint
+++ b/test/no-single-declare-module/wrong.d.ts.lint
@@ -1,5 +1,5 @@
 declare module "foo" {}
-~~~~~~~~~~~~~~~~~~~~~~~  [File has only 1 module declaration — write it as an external module. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-single-declare-module.md]
+~~~~~~~~~~~~~~~~~~~~~~~  [File has only 1 ambient module declaration. Move the contents outside the ambient module block, rename the file to match the ambient module name, and remove the block. See: https://github.com/Microsoft/dtslint/blob/master/docs/no-single-declare-module.md]
 
 // Other global declarations don't affect this. They should go in "declare global".
 interface I {}


### PR DESCRIPTION
The term now is just 'module'. I improved the wording while I was here.