### PR TITLE
Add concurrency explanation -> FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,6 @@ I'm getting an error about a missing typescript install.
 Error: Cannot find module '/node_modules/dtslint/typescript-installs/3.1/node_modules/typescript`
 ```
 Package lock files such as `yarn.lock` and `package-lock.json` may cause this issue because of our github dependency on `"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production"`, which contains the list of typescript versions to install. To fix this, try deleting your lock file and re-installing.
+
+Alternatively this error can be caused by concurrent dtslint invocations trampling each other's TypeScript installations, especially in the context of continuous integration, if dtslint is installed from scratch in each run.
+If for example you use [Lerna](https://github.com/lerna/lerna/tree/main/commands/run#readme), try running dtslint with [`lerna --concurrency 1 run ...`](https://github.com/lerna/lerna/tree/main/core/global-options#--concurrency).

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ I'm getting an error about a missing typescript install.
 ```
 Error: Cannot find module '/node_modules/dtslint/typescript-installs/3.1/node_modules/typescript`
 ```
-Package lock files such as `yarn.lock` and `package-lock.json` may cause this issue because of our github dependency on `"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production"`, which contains the list of typescript versions to install. To fix this, try deleting your lock file and re-installing.
+Your dependencies may be out of date.
+[@definitelytyped/typescript-versions](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/typescript-versions) is the package that contains the list of TypeScript versions to install.
 
 Alternatively this error can be caused by concurrent dtslint invocations trampling each other's TypeScript installations, especially in the context of continuous integration, if dtslint is installed from scratch in each run.
 If for example you use [Lerna](https://github.com/lerna/lerna/tree/main/commands/run#readme), try running dtslint with [`lerna --concurrency 1 run ...`](https://github.com/lerna/lerna/tree/main/core/global-options#--concurrency).


### PR DESCRIPTION
I ran into this issue [here](https://github.com/mdx-js/mdx/pull/1622/checks?check_run_id=3451812571#step:5:373):
```
$ lerna run test-types
lerna notice cli v3.22.1
lerna info ci enabled
lerna info Executing command in 8 packages: "yarn run test-types"
lerna ERR! yarn run test-types exited 1 in '@mdx-js/react'
lerna ERR! yarn run test-types stdout:
$ dtslint types
Installing to /home/runner/.dts/typescript-installs/3.8...
Installed!

Installing to /home/runner/.dts/typescript-installs/4.0...
Installed!

Installing to /home/runner/.dts/typescript-installs/4.2...
Installed!

Installing to /home/runner/.dts/typescript-installs/4.3...
Installed!

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run test-types stderr:
Error: Cannot find module '/home/runner/.dts/typescript-installs/4.5/node_modules/typescript'
Require stack:
- /home/runner/work/mdx/mdx/node_modules/dtslint/bin/lint.js
- /home/runner/work/mdx/mdx/node_modules/dtslint/bin/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:94:18)
    at testDependencies (/home/runner/work/mdx/mdx/node_modules/dtslint/bin/lint.js:66:16)
    at /home/runner/work/mdx/mdx/node_modules/dtslint/bin/lint.js:26:28
    at Generator.next (<anonymous>)
    at /home/runner/work/mdx/mdx/node_modules/dtslint/bin/lint.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/runner/work/mdx/mdx/node_modules/dtslint/bin/lint.js:4:12)
error Command failed with exit code 1.
```

The failed invocation installed 3.8, 4.0, etc., a concurrent invocation installed 3.9, 4.5, etc. The failed invocation found the 4.5 directory but didn't wait for the 4.5 installation to complete and failed as a result (I surmise).

Solved with [`lerna --concurrency 1 run ...`](https://github.com/mdx-js/mdx/pull/1622#discussion_r697920090). I suspect this is also the cause behind https://github.com/mdx-js/mdx/issues/1172 and #267.

Fixes #267