### PR TITLE
Sync README tsconfig.json with dts-gen template

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Refer to the [handbook](http://www.typescriptlang.org/docs/handbook/declaration-
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "types": [],
         "noEmit": true,
+        "forceConsistentCasingInFileNames: true,
 
         // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
         // If the library is global (cannot be imported via `import` or `require`), leave this out.


### PR DESCRIPTION
Does it make sense to synchronize the `tsconfig.json` prescribed in the README with the dts-gen template? https://github.com/microsoft/dts-gen/blob/af84657554e01fcfa81b210a43efd8236f476fd4/lib/definitely-typed.ts#L100-L110

This PR adds `"types": []` and `"forceConsistentCasingInFileNames: true` to the README. Similar to #77 and #122 although the current example probably only actually errors on DefinitelyTyped, not if you're running dtslint on some other library: https://github.com/microsoft/dtslint/blob/33eb773bb8213bfdc0d938d309270e5fb5173a66/src/checks.ts#L61-L71

Still, I maybe ran into this [here](https://github.com/mdx-js/mdx/pull/1622#:~:text=the%20issue%20i%20encountered%20was%20dtslint%20implicitly%20including%20and%20checking%20every%20node_modules%2F%40types%20declaration%3A) -- the `tsconfig.json` in that case might have been based on the dtslint README, and probably most libraries want `"types": []`, to avoid implicitly including and linting every `node_modules/@types` declaration (in a monorepo with a bunch of dependencies that can be a lot of checks, multiplied by the number of linted workspaces).