### PR TITLE
Allow package.json files to specify imports/exports/type

### DIFF
--- a/src/checks.ts
+++ b/src/checks.ts
@@ -37,6 +37,9 @@ export async function checkPackageJson(
             case "private":
             case "dependencies":
             case "license":
+            case "imports":
+            case "exports":
+            case "type":
                 // "private"/"typesVersions"/"types" checked above, "dependencies" / "license" checked by types-publisher,
                 break;
             case "typesVersions":


### PR DESCRIPTION
So we can start using them on DT. (The publisher has already been updated to allow them)