### PR TITLE
Exclude `download-git-repo` from forbidden words

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,7 @@ function assertPathIsNotBanned(dirPath: string) {
     if (/(^|\W)download($|\W)/.test(basedir) &&
         basedir !== "download" &&
         basedir !== "downloadjs" &&
+        basedir !== "download-git-repo" &&
         basedir !== "s3-download-stream") {
         // Since npm won't release their banned-words list, we'll have to manually add to this list.
         throw new Error(`${dirPath}: Contains the word 'download', which is banned by npm.`);


### PR DESCRIPTION
This package already exists on npm, so if I understand the matter correctly, it should be allowed here, too:

https://www.npmjs.com/package/download-git-repo

Complements ad7eb6011049ed560053864df9040576d9d1180a. Required for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56874.