### PR TITLE
Update missing node assertion error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import { f } from "my-lib"; // f is(n: number) => void
 // $ExpectType void
 f(1);
 
-// Can also write the assertion on the same line.
+// Can also write the assertion on the same line (but not if it's a multiline function call).
 f(2); // $ExpectType void
 
 // $ExpectError

--- a/src/rules/expectRule.ts
+++ b/src/rules/expectRule.ts
@@ -27,7 +27,7 @@ export class Rule extends Lint.Rules.TypedRule {
     /* tslint:enable:object-literal-sort-keys */
 
     static FAILURE_STRING_DUPLICATE_ASSERTION = "This line has 2 $ExpectType assertions.";
-    static FAILURE_STRING_ASSERTION_MISSING_NODE = "Can not match a node to this assertion.";
+    static FAILURE_STRING_ASSERTION_MISSING_NODE = "Can not match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above.";
     static FAILURE_STRING_EXPECTED_ERROR = "Expected an error on this line, but found none.";
 
     static FAILURE_STRING(expectedVersion: string, expectedType: string, actualType: string): string {

--- a/test/expect/expectType.ts.lint
+++ b/test/expect/expectType.ts.lint
@@ -1,7 +1,7 @@
 
 // $ExpectType xxx
 
-~nil [TypeScript@next: Can not match a node to this assertion.]
+~nil [TypeScript@next: Can not match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above.]
 
 // $ExpectType number[]
 [1, 2];
@@ -21,6 +21,15 @@ declare function f(
 
 // Test that we never truncate types.
 f; // $ExpectType (one: number, two: [number, number], three: [number, number, number], four: [number, number, number, number]) => number
+
+// Test assertion at the end of a multiline function call
+f(
+    1,
+    [2, 2],
+    [3, 3, 3,],
+    [4, 4, 4, 4]
+) // $ExpectType number;
+~~~~~~~~~~~~~~~~~~~~~~~~ [TypeScript@next: Can not match a node to this assertion. If this is a multiline function call, ensure the assertion is on the line above.]
 
 // Test that we get the type of the initializer on a variable declaration.
 // $ExpectType 1


### PR DESCRIPTION
When updating TypeScript definitions for DefinitelyTyped, I encounter the following error:

```
ERROR: 19:1  expect  TypeScript@4.7: Can not match a node to this assertion.
```

I found an open issue in this repo which mentions the issue, but the specifics of the situation seems unrelated: https://github.com/microsoft/dtslint/issues/157, and it wasn't until I found this comment that I understood what the problem was: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51161#issuecomment-777039728:

> Ok in dtslint readme there's two ways of using it: before and at the end of the line. So I guess the multiline structure is thee cause of the problem.

In this instance Prettier had formatted my code to be multiline, instead of single line function calls. I thought it could be helpful to add some extra information to this error in case others encounter it in the future.